### PR TITLE
linux: add a gtk3 based message_box/1 implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  ubuntu:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list; sudo apt-get update; sudo apt-get install --quiet -y libglfw3 libglfw3-dev libfreetype6-dev
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
+        sudo apt-get update
+        sudo apt-get install --quiet -y libglfw3 libglfw3-dev libfreetype6-dev libgtk-3-dev
     - name: Build examples
       run: |
         cd ..

--- a/ui_linux.v
+++ b/ui_linux.v
@@ -6,24 +6,16 @@ module ui
 #include <gtk/gtk.h>
 #flag `pkg-config --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0`
 
-type Callback fn (voidptr)
 struct C.GtkWidget{}
-struct C.GtkDialogFlags{}
 struct C.GtkDialog{}
-fn C.gtk_init(int, &charptr)
-fn C.gtk_main_quit()
-fn C.gtk_main()
-fn C.gtk_message_dialog_new(voidptr, int, int, int, charptr) &GtkWidget
-fn C.GTK_DIALOG(w &GtkWidget) &GtkDialog
-//fn C.gtk_dialog_run(d &GtkDialog) int
-fn C.gtk_widget_destroy(w &GtkWidget)
-fn C.gtk_widget_show(w &GtkWidget)
-fn C.gtk_widget_hide(w &GtkWidget)
+type Callback fn (voidptr)
 fn C.g_signal_connect_swapped(inst &GtkWidget, signal charptr, cb Callback, obj &GtkWidget)
-
-const (
-	response_signal_name = 'response'
-)
+fn C.gtk_init(int, &charptr)
+fn C.gtk_main()
+fn C.gtk_main_quit()
+fn C.gtk_message_dialog_new(voidptr, int, int, int, charptr) &GtkWidget
+fn C.gtk_widget_show(w &GtkWidget)
+fn C.gtk_widget_destroy(w &GtkWidget)
 
 fn message_box_close(w &GtkWidget){
 	C.gtk_widget_destroy(w)
@@ -33,7 +25,7 @@ fn message_box_close(w &GtkWidget){
 pub fn message_box(s string) {
 	gtk_init(0, [''].data)
 	dialog := C.gtk_message_dialog_new( 0, C.GTK_DIALOG_DESTROY_WITH_PARENT, C.GTK_MESSAGE_INFO, C.GTK_BUTTONS_OK, s.str)
-	C.g_signal_connect_swapped( dialog, response_signal_name.str, message_box_close as Callback, dialog )
+	C.g_signal_connect_swapped( dialog, 'response'.str, message_box_close as Callback, dialog )
 	C.gtk_widget_show(dialog)
 	C.gtk_main()
 }

--- a/ui_linux.v
+++ b/ui_linux.v
@@ -3,7 +3,6 @@
 // that can be found in the LICENSE file.
 module ui
 
-import os
 #include <gtk/gtk.h>
 #flag `pkg-config --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0`
 
@@ -32,7 +31,7 @@ fn message_box_close(w &GtkWidget){
 }
 
 pub fn message_box(s string) {
-	gtk_init(os.args.len - 1, os.args.data)
+	gtk_init(0, [''].data)
 	dialog := C.gtk_message_dialog_new( 0, C.GTK_DIALOG_DESTROY_WITH_PARENT, C.GTK_MESSAGE_INFO, C.GTK_BUTTONS_OK, s.str)
 	C.g_signal_connect_swapped( dialog, response_signal_name.str, message_box_close as Callback, dialog )
 	C.gtk_widget_show(dialog)

--- a/ui_linux.v
+++ b/ui_linux.v
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file.
 module ui
 
+import os
 #include <gtk/gtk.h>
 #flag `pkg-config --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0`
 
@@ -10,7 +11,7 @@ type Callback fn (voidptr)
 struct C.GtkWidget{}
 struct C.GtkDialogFlags{}
 struct C.GtkDialog{}
-fn C.gtk_init(int, voidptr)
+fn C.gtk_init(int, &charptr)
 fn C.gtk_main_quit()
 fn C.gtk_main()
 fn C.gtk_message_dialog_new(voidptr, int, int, int, charptr) &GtkWidget
@@ -31,7 +32,7 @@ fn message_box_close(w &GtkWidget){
 }
 
 pub fn message_box(s string) {
-	gtk_init(0, [''].data)
+	gtk_init(os.args.len - 1, os.args.data)
 	dialog := C.gtk_message_dialog_new( 0, C.GTK_DIALOG_DESTROY_WITH_PARENT, C.GTK_MESSAGE_INFO, C.GTK_BUTTONS_OK, s.str)
 	C.g_signal_connect_swapped( dialog, response_signal_name.str, message_box_close as Callback, dialog )
 	C.gtk_widget_show(dialog)

--- a/ui_linux.v
+++ b/ui_linux.v
@@ -3,7 +3,37 @@
 // that can be found in the LICENSE file.
 module ui
 
-pub fn message_box(s string) {
-	// TODO
+#include <gtk/gtk.h>
+#flag `pkg-config --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0`
+
+type Callback fn (voidptr)
+struct C.GtkWidget{}
+struct C.GtkDialogFlags{}
+struct C.GtkDialog{}
+fn C.gtk_init(int, voidptr)
+fn C.gtk_main_quit()
+fn C.gtk_main()
+fn C.gtk_message_dialog_new(voidptr, int, int, int, charptr) &GtkWidget
+fn C.GTK_DIALOG(w &GtkWidget) &GtkDialog
+//fn C.gtk_dialog_run(d &GtkDialog) int
+fn C.gtk_widget_destroy(w &GtkWidget)
+fn C.gtk_widget_show(w &GtkWidget)
+fn C.gtk_widget_hide(w &GtkWidget)
+fn C.g_signal_connect_swapped(inst &GtkWidget, signal charptr, cb Callback, obj &GtkWidget)
+
+const (
+	response_signal_name = 'response'
+)
+
+fn message_box_close(w &GtkWidget){
+	C.gtk_widget_destroy(w)
+	C.gtk_main_quit()
 }
 
+pub fn message_box(s string) {
+	gtk_init(0, [''].data)
+	dialog := C.gtk_message_dialog_new( 0, C.GTK_DIALOG_DESTROY_WITH_PARENT, C.GTK_MESSAGE_INFO, C.GTK_BUTTONS_OK, s.str)
+	C.g_signal_connect_swapped( dialog, response_signal_name.str, message_box_close as Callback, dialog )
+	C.gtk_widget_show(dialog)
+	C.gtk_main()
+}


### PR DESCRIPTION
Based on https://gtk-rs.org/docs/gtk/struct.MessageDialog.html , with some
modifications to actually *destroy* the dialog, when it is not needed.