### PR TITLE
add slider control

### DIFF
--- a/button.v
+++ b/button.v
@@ -92,6 +92,8 @@ fn (b mut Button) click(e MouseEvent) {
 	}
 }
 
+fn (b mut Button) mouse_move(e MouseEvent) {}
+
 fn (b mut Button) focus() {
 	b.is_focused = true
 }
@@ -102,6 +104,10 @@ fn (b mut Button) unfocus() {
 
 fn (b &Button) idx() int {
 	return b.idx
+}
+
+fn (t &Button) typ() WidgetType {
+	return .Button
 }
 
 fn (t &Button) is_focused() bool {

--- a/canvas.v
+++ b/canvas.v
@@ -45,11 +45,18 @@ fn (t &Canvas) key_down(e KeyEvent) {}
 
 fn (t &Canvas) click(e MouseEvent) {
 }
+fn (t &Canvas) mouse_move(e MouseEvent) {
+}
+
 
 fn (t &Canvas) focus() {}
 
 fn (t &Canvas) idx() int {
 	return t.idx
+}
+
+fn (t &Canvas) typ() WidgetType {
+	return .Canvas
 }
 
 fn (t &Canvas) is_focused() bool {

--- a/checkbox.v
+++ b/checkbox.v
@@ -96,6 +96,8 @@ fn (b mut CheckBox) click(e MouseEvent) {
 	}
 }
 
+fn (b mut CheckBox) mouse_move(e MouseEvent) {}
+
 fn (b mut CheckBox) focus() {
 	b.is_focused = true
 }
@@ -106,6 +108,9 @@ fn (b mut CheckBox) unfocus() {
 
 fn (b &CheckBox) idx() int {
 	return b.idx
+}
+fn (t &CheckBox) typ() WidgetType {
+	return .CheckBox
 }
 
 fn (t &CheckBox) is_focused() bool {

--- a/key.v
+++ b/key.v
@@ -7,6 +7,8 @@ module ui
 pub enum Key {
 	left = 263
 	right = 262
+	arrow_up = 264
+	arrow_down = 265
 	backspace = 259
 	delete = 261
 	tab = 258
@@ -22,4 +24,3 @@ pub enum KeyMod {
 	alt = 4
 	super = 8
 }
-

--- a/label.v
+++ b/label.v
@@ -40,11 +40,17 @@ fn (t &Label) key_down(e KeyEvent) {}
 
 fn (t &Label) click(e MouseEvent) {
 }
+fn (t &Label) mouse_move(e MouseEvent) {
+}
 
 fn (t &Label) focus() {}
 
 fn (t &Label) idx() int {
 	return t.idx
+}
+
+fn (t &Label) typ() WidgetType {
+	return .Label
 }
 
 fn (t &Label) is_focused() bool {

--- a/menu.v
+++ b/menu.v
@@ -75,10 +75,17 @@ fn (t &Menu) key_down(e KeyEvent) {}
 fn (t &Menu) click(e MouseEvent) {
 }
 
+fn (t &Menu) mouse_move(e MouseEvent) {
+}
+
 fn (t &Menu) focus() {}
 
 fn (t &Menu) idx() int {
 	return t.idx
+}
+
+fn (t &Menu) typ() WidgetType {
+	return .Menu
 }
 
 fn (t &Menu) is_focused() bool {

--- a/picture.v
+++ b/picture.v
@@ -53,6 +53,8 @@ fn (t &Picture) key_down(e KeyEvent) {}
 
 fn (t &Picture) click(e MouseEvent) {
 }
+fn (t &Picture) mouse_move(e MouseEvent) {
+}
 
 fn (t &Picture) focus() {}
 
@@ -62,6 +64,10 @@ fn (t &Picture) idx() int {
 
 fn (t &Picture) is_focused() bool {
 	return false
+}
+
+fn (t &Picture) typ() WidgetType {
+	return .Picture
 }
 
 fn (t &Picture) unfocus() {}

--- a/progressbar.v
+++ b/progressbar.v
@@ -73,6 +73,8 @@ fn (t &ProgressBar) point_inside(x, y f64) bool {
 
 fn (b &ProgressBar) click(e MouseEvent) {
 }
+fn (b &ProgressBar) mouse_move(e MouseEvent) {
+}
 
 fn (b &ProgressBar) focus() {
 }
@@ -83,6 +85,10 @@ fn (b &ProgressBar) idx() int {
 
 fn (t &ProgressBar) is_focused() bool {
 	return t.is_focused
+}
+
+fn (t &ProgressBar) typ() WidgetType {
+	return .ProgressBar
 }
 
 fn (b &ProgressBar) unfocus() {

--- a/radio.v
+++ b/radio.v
@@ -107,6 +107,9 @@ fn (r mut Radio) click(e MouseEvent) {
 	//println(r.selected_index)
 }
 
+fn (r &Radio) mouse_move(e MouseEvent) {
+}
+
 fn (b mut Radio) focus() {
 	b.is_focused = true
 }
@@ -117,6 +120,10 @@ fn (b mut Radio) unfocus() {
 
 fn (b &Radio) idx() int {
 	return b.idx
+}
+
+fn (t &Radio) typ() WidgetType {
+	return .Radio
 }
 
 pub fn (r &Radio) selected_value() string {

--- a/slider.v
+++ b/slider.v
@@ -1,0 +1,204 @@
+module ui
+
+import gx
+import glfw
+
+const (
+	thumb_color = gx.rgb(87, 153, 245)
+	slider_background_color = gx.rgb(219, 219, 219)
+	slider_background_border_color = gx.rgb(191, 191, 191)
+)
+
+type SliderValueChangedFn fn(voidptr, voidptr)
+
+pub enum Orientation {
+	vertical = 0,
+	horizontal = 1
+}
+
+pub struct Slider {
+pub mut:
+	idx        int
+	track_height     int
+	track_width      int
+	thumb_width 	 int
+	thumb_height 	 int
+	orientation      Orientation
+	x          int
+	y          int
+	parent     &ui.Window
+	ui         &UI
+	val        f32
+	min        int
+	max        int
+	is_focused bool
+	dragging   bool
+	on_value_changed SliderValueChangedFn
+}
+
+pub struct SliderConfig {
+	x      int
+	y      int
+	width  int
+	height int
+	min    int
+	max    int
+	val    f32
+	orientation      Orientation
+	parent &ui.Window
+	on_value_changed SliderValueChangedFn
+}
+
+pub fn new_slider(c SliderConfig) &Slider {
+	mut p := &Slider{
+		track_height: c.height
+		track_width: c.width
+		x: c.x
+		y: c.y
+		parent: c.parent
+		ui: c.parent.ui
+		idx: c.parent.children.len
+		min: c.min
+		max: c.max
+		val: c.val
+		orientation: c.orientation
+		on_value_changed: c.on_value_changed
+	}
+	p.thumb_height = if p.orientation == .horizontal {p.track_height * 3} else {10}
+	p.thumb_width = if p.orientation == .horizontal { 10 } else {p.track_width * 3}
+	p.parent.children << p
+	p.parent.on_click(on_window_click)
+	p.parent.on_mousemove(on_window_mouse_move)
+	return p
+}
+
+fn (b &Slider) draw_thumb() {
+	dim := if b.orientation == .horizontal { b.track_width } else {b.track_height}
+	rev_dim := if b.orientation == .horizontal { b.track_height } else { b.track_width }
+	axis := if b.orientation == .horizontal {b.x} else {b.y}
+	rev_axis := if b.orientation == .horizontal {b.y} else {b.x}
+
+	mut pos := f32(dim) * (b.val / f32(b.max))
+	if (pos > dim) {pos = f32(dim)}
+	if (pos < axis) {pos = axis}
+
+	middle := f32(rev_axis) - rev_dim - f32(rev_dim / 3)
+
+	if b.orientation == .horizontal {
+		b.ui.gg.draw_rect(pos, middle, b.thumb_width, b.thumb_height, thumb_color)
+	} else {
+		b.ui.gg.draw_rect(middle, pos, b.thumb_width, b.thumb_height, thumb_color)
+	}
+}
+
+fn (b &Slider) draw() {
+	// Draw the track
+	b.ui.gg.draw_rect(b.x, b.y, b.track_width, b.track_height, slider_background_color)
+	b.ui.gg.draw_empty_rect(b.x, b.y, b.track_width, b.track_height, slider_background_border_color)
+
+	// Draw the thumb
+	b.draw_thumb()
+}
+
+fn (b mut Slider) key_down(e KeyEvent) {
+	match e.key {
+		.arrow_down, .left {
+			if b.val > b.min {
+				b.val--
+			}
+		}
+		.arrow_up, .right {
+			if b.val < b.max {
+				b.val++
+			}
+		} else{}
+	}
+}
+
+fn (t &Slider) point_inside(x, y f64) bool {
+	return x >= t.x && x <= t.x + t.track_width && y >= t.y && y <= t.y + (t.track_height + t.thumb_height)
+}
+
+fn on_window_click(e MouseEvent, ptr voidptr) {
+	// we use a global window_click listener so that if
+	// the user releases the mouse button outside the slider
+	// area we can turn the dragging off.
+	window := &ui.Window(ptr)
+	for child in window.children {
+		typ := child.typ()
+		inside := child.point_inside(e.x, e.y)
+		if typ == .Slider {
+			if e.action == 0 && !inside {
+				child.click(e)
+			}
+			break
+		}
+	}
+}
+
+fn on_window_mouse_move(e MouseEvent, ptr voidptr) {
+	// we use a global window_mouse listener so the user can
+	// keep dragging when his mouse moves outside the slider area.
+	window := &ui.Window(ptr)
+	for child in window.children {
+		typ := child.typ()
+		inside := child.point_inside(e.x, e.y)
+		if typ == .Slider {
+			if !inside {
+				child.mouse_move(e)
+			}
+			break
+		}
+	}
+}
+
+fn (b mut Slider) click(e MouseEvent) {
+	if !b.point_inside(e.x, e.y)  {
+		b.dragging = false
+		return
+	}
+	b.change_value(e.x, e.y)
+	b.is_focused = true
+	b.dragging = e.action == 1
+}
+
+fn (b mut Slider) mouse_move(e MouseEvent) {
+	if b.dragging {
+		b.change_value(e.x, e.y)
+	}
+}
+
+fn (b mut Slider) change_value(x, y int) {
+	divisor := if b.orientation == .horizontal {b.track_width} else {b.track_height}
+	axis := if b.orientation == .horizontal {x} else {y}
+	b.val = f32(axis) * f32(b.max) / f32(divisor)
+	if int(b.val) < b.min {
+		b.val = b.min
+	} else if int(b.val) > b.max {
+		b.val = b.max
+	}
+	if b.on_value_changed != 0 {
+		b.on_value_changed(b.parent.user_ptr, b)
+	}
+}
+
+fn (b mut Slider) focus() {
+	b.parent.unfocus_all()
+	b.is_focused = true
+}
+
+fn (b &Slider) idx() int {
+	return b.idx
+}
+
+fn (t &Slider) typ() WidgetType {
+	return .Slider
+}
+
+fn (t &Slider) is_focused() bool {
+	return t.is_focused
+}
+
+fn (b mut Slider) unfocus() {
+	b.is_focused = false
+}

--- a/textbox.v
+++ b/textbox.v
@@ -284,7 +284,7 @@ fn (t mut TextBox) key_down(e KeyEvent) {
 fn (t &TextBox) point_inside(x, y f64) bool {
 	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
 }
-
+fn (t mut TextBox) mouse_move(e MouseEvent) {}
 fn (t mut TextBox) click(e MouseEvent) {
 	t.ui.show_cursor = true
 	t.focus()
@@ -318,6 +318,10 @@ pub fn (t mut TextBox) focus() {
 
 fn (t &TextBox) idx() int {
 	return t.idx
+}
+
+fn (t &TextBox) typ() WidgetType {
+	return .TextBox
 }
 
 fn (t &TextBox) is_focused() bool {

--- a/ui.v
+++ b/ui.v
@@ -26,15 +26,30 @@ mut:
 	clipboard            &clipboard.Clipboard
 }
 
+pub enum WidgetType {
+	Button,
+	Canvas,
+	CheckBox,
+	Label,
+	Menu,
+	Picture,
+	ProgressBar,
+	Radio,
+	Slider,
+	TextBox
+}
+
 // TODO rename to `Widget` once interfaces allow that :)
 pub interface IWidgeter {
 	key_down(KeyEvent)
 	draw()
 	click(MouseEvent)
+	mouse_move(MouseEvent)
 	point_inside(x, y f64) bool
 	unfocus()
 	focus()
 	idx() int
+	typ() WidgetType
 	is_focused() bool
 }
 


### PR DESCRIPTION
I have added a fully functional multi-orientation slider. It supports:
* Dragging
* Move to clicked point
* Vertical/Horizontal Orientations

There is no support for:
* Ticks (will be added soon)
* Tooltip (had added it but removed it due to hacky impl)

All values are in `f32` so fairly precise. 

I had planned on making the thumb round but unfortunately v's `gg` doesn't support `draw_circle` function yet so had to fall back to `draw_rect`.

Working on an example for basic usage.