### PR TITLE
add text selection by keyboard and mouse

### DIFF
--- a/key.v
+++ b/key.v
@@ -24,6 +24,7 @@ pub enum KeyMod {
 	shift = 1
 	alt = 4
 	super = 8
+	ctrl = 2
 }
 
 pub enum KeyState {


### PR DESCRIPTION
This PR adds text selection by keyboard and mouse.

Holding shift and using arrow keys will select one letter forward or backward.
Holding ctrl+shift and using arrow keys will select until the next whitespace in the respective direction.

Selection with mouse is as usual.