### PR TITLE
make ctrl + backspace work

### DIFF
--- a/key.v
+++ b/key.v
@@ -24,6 +24,7 @@ pub enum KeyMod {
 	shift = 1
 	alt = 4
 	super = 8
+	ctrl = 2
 }
 
 pub enum KeyState {

--- a/textbox.v
+++ b/textbox.v
@@ -249,6 +249,19 @@ fn tb_key_down(t mut TextBox, e &KeyEvent, window &ui.Window ) {
 					t.cursor_pos = t.sel_start
 					t.sel_start = 0
 					t.sel_end = 0
+				} else if e.mods in [.super, .ctrl] {
+					// Delete until previous whitespace
+					mut i := t.cursor_pos
+					for {
+						if i > 0 {
+							i--
+						}
+						if t.text[i].is_white() || i == 0 {
+							t.text = u.left(i) + u.right(t.cursor_pos)
+							break
+						}
+					}
+					t.cursor_pos = i
 				} else {
 					// Delete just one character
 					t.text = u.left(t.cursor_pos - 1) + u.right(t.cursor_pos)


### PR DESCRIPTION
This PR adds CTRL+Backspace functionality to erase whole words quickly.