### PR TITLE
Fix slider position (keep them in the middle of the position)

### DIFF
--- a/slider.v
+++ b/slider.v
@@ -94,9 +94,9 @@ fn (b &Slider) draw_thumb() {
 	middle := f32(rev_axis) - ((rev_thumb_dim - rev_dim) / 2)
 
 	if b.orientation == .horizontal {
-		b.ui.gg.draw_rect(pos, middle, b.thumb_width, b.thumb_height, thumb_color)
+		b.ui.gg.draw_rect(pos - b.thumb_width / 2, middle, b.thumb_width, b.thumb_height, thumb_color)
 	} else {
-		b.ui.gg.draw_rect(middle, pos, b.thumb_width, b.thumb_height, thumb_color)
+		b.ui.gg.draw_rect(middle, pos - b.thumb_height / 2, b.thumb_width, b.thumb_height, thumb_color)
 	}
 }
 


### PR DESCRIPTION
Sliders are not drawn from the middle of the "position", this PR fix it

![2020-02-07 00-38-32 2020-02-07 00_39_43](https://user-images.githubusercontent.com/588205/73988241-59b62580-4942-11ea-8099-768c5ef00281.gif)
