### PR TITLE
fix message box on windows, part 2

### DIFF
--- a/ui_windows.v
+++ b/ui_windows.v
@@ -7,6 +7,6 @@ fn C.MessageBox(h voidptr, text charptr, caption charptr, kind u32) int
 
 pub fn message_box(s string) {
 	title := ''
-	C.MessageBox(0, s.str, title.to_wide(), C.MB_OK)
+	C.MessageBox(0, s.to_wide(), title.to_wide(), C.MB_OK)
 }
 


### PR DESCRIPTION
`message` argument should be also LPCTSTR.