### PR TITLE
examples: fix building timer

### DIFF
--- a/examples/timer.v
+++ b/examples/timer.v
@@ -24,7 +24,7 @@ fn main() {
 			orientation: .horizontal
 			max: 50
 			min: 0
-			val: app.duration
+			val: 25.0
 			//on_value_changed: on_value_changed
 		)
 		progress_bar: ui.progressbar(


### PR DESCRIPTION
The example still does not work (the window closes immediately after it's displayed).