### PR TITLE
examples: fix timer example

### DIFF
--- a/examples/timer.v
+++ b/examples/timer.v
@@ -2,36 +2,40 @@ import ui
 import time
 
 const (
-	win_width = 287
+	win_width  = 287
 	win_height = 110
 )
 
 struct App {
 mut:
 	lbl_elapsed_value &ui.Label
-	progress_bar &ui.ProgressBar
-	slider &ui.Slider
-	window     &ui.Window
-	duration f64 = 25.0
-	elapsed_time f64 = 0.0
+	progress_bar      &ui.ProgressBar
+	slider            &ui.Slider
+	window            &ui.Window
+	duration          f64 = 25.0
+	elapsed_time      f64 = 0.0
 }
 
 fn main() {
 	mut app := &App{
-		slider:	ui.slider(
+		slider: ui.slider({
 			width: 180
 			height: 20
 			orientation: .horizontal
 			max: 50
 			min: 0
 			val: 25.0
-			//on_value_changed: on_value_changed
-		)
-		progress_bar: ui.progressbar(
-				height: 20
-				val: 0
-				max: 100
-		)
+			on_value_changed: on_value_changed
+		})
+		lbl_elapsed_value: ui.label({
+			text: '00.0s'
+		})
+		progress_bar: ui.progressbar({
+			height: 20
+			val: 0
+			max: 100
+		})
+		window: 0
 	}
 	window := ui.window({
 		width: win_width
@@ -44,37 +48,34 @@ fn main() {
 			margin: ui.MarginConfig{5,5,5,5}
 			alignment: .left
 		}, [
-		ui.row({
-			alignment: .top
-			spacing: 10
-		}, [
-			ui.column({
-				alignment: .left
+			ui.row({
+				alignment: .top
 				spacing: 10
 			}, [
-				ui.label(
-					text: 'Elapsed Time:'
-				)
-				ui.label(
-					text: 'Duration:'
-				)
-				ui.button(
-					text: 'Reset'
-					//onclick: on_reset
-				)
+				ui.column({
+					alignment: .left
+					spacing: 10
+				}, [
+					ui.label({
+						text: 'Elapsed Time:'
+					}),
+					ui.label({
+						text: 'Duration:'
+					}),
+					ui.button({
+						text: 'Reset'
+						onclick: on_reset
+					})
+				]),
+				ui.column({
+					alignment: .left
+					spacing: 10
+				}, [
+					app.lbl_elapsed_value,
+					app.slider
+				])
 			]),
-			ui.column({
-				alignment: .left
-				spacing: 10
-			}, [
-				ui.label(
-					text: '00.0s'
-					//ref:  &app.lbl_elapsed_value
-				)
-				app.slider
-			])
-		]),
-		app.progress_bar
+			app.progress_bar
 		])
 	])
 	app.window = window
@@ -82,15 +83,15 @@ fn main() {
 	ui.run(window)
 }
 
-fn on_value_changed(app mut App) {
+fn on_value_changed(mut app App, slider &ui.Slider) {
 	app.duration = app.slider.val
 }
 
-fn on_reset(app mut App) {
+fn on_reset(mut app App, button &ui.Button) {
 	app.elapsed_time = 0.0
 }
 
-fn (app mut App) timer() {
+fn (mut app App) timer() {
 	for {
 		if app.elapsed_time == app.duration {
 			continue
@@ -100,7 +101,7 @@ fn (app mut App) timer() {
 		} else {
 			app.elapsed_time += 0.1
 		}
-		app.lbl_elapsed_value.set_text(app.elapsed_time.str() + "s")
+		app.lbl_elapsed_value.set_text('${app.elapsed_time} s')
 		if app.duration == 0 {
 			app.progress_bar.val = 100
 		} else {


### PR DESCRIPTION
## Changelog

- Fixed the example
- Fixed warnings
- Reformatted code with `v fmt`
- Used string interpolation to show elapsed seconds
This resolves an issue where elapsed seconds were displayed in an exponential form.