### PR TITLE
examples: fix uninitialized App.window reference field on change_title.v

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ examples/*.exe
 examples/*.ilk
 examples/*.pdb
 examples/calculator
+examples/change_title
 examples/counter
 examples/dropdown
 examples/group

--- a/examples/change_title.v
+++ b/examples/change_title.v
@@ -13,6 +13,7 @@ mut:
 
 fn main() {
 	mut app := &App{
+		window: 0
 		title_box: ui.textbox(
 			max_len: 20
 			width: 300


### PR DESCRIPTION
This PR satisfies the compiler's complaint (V `0.1.27` 7c9bb44)

```sh
~> v run examples/change_title.v
examples/change_title.v:15:14: warning: reference field `App.window` must be initialized 
   13 | 
   14 | fn main() {
   15 |     mut app := &App{
      |                 ~~~~
   16 |         title_box: ui.textbox(
   17 |             max_len: 20
```

Additionally it appends its binary to `.gitignore`