### PR TITLE
Make FreeType and GG public and mutable on UI struct

### DIFF
--- a/ui.v
+++ b/ui.v
@@ -18,7 +18,7 @@ const (
 )
 
 pub struct UI {
-pub:
+pub mut:
 	ft                   &freetype.FreeType = voidptr(0)
 	gg                   &gg.GG = voidptr(0)
 mut:


### PR DESCRIPTION
Fixes a BUNCH of compile errors when trying to build the examples directory. However I'm not sure the reason why this was originally not made mutable.

Addresses https://github.com/vlang/ui/issues/150