### PR TITLE
Allow running build_examples.vsh from a different working dir

### DIFF
--- a/examples/build_examples.vsh
+++ b/examples/build_examples.vsh
@@ -1,12 +1,13 @@
 import os
 
-files := os.ls('.') or { return }
+examples_dir := @FILE.all_before('build_examples.vsh')
+files := os.ls(examples_dir) or { return }
 for file in files {
 	if !file.ends_with('.v') {
 		continue
 	}
 	println(file)
-	ret := os.system('v -w $file')
+	ret := os.system('v -w ${examples_dir + file}')
 	if ret != 0 {
 		println('failed')
 		exit(1)


### PR DESCRIPTION
`.` as relative path refers to the current working dir.
E.g. running `v run examples/build_examples.vsh` also tried to compile all UI .v files