### PR TITLE
v.mod, ui.v: Bump version to 0.0.3

### DIFF
--- a/ui.v
+++ b/ui.v
@@ -14,7 +14,7 @@ import eventbus
 import gx
 
 const (
-	version = '0.0.2'
+	version = '0.0.3'
 )
 
 pub struct UI {

--- a/v.mod
+++ b/v.mod
@@ -1,7 +1,7 @@
 Module {
         name: 'ui'
         author: 'medvednikov'
-        version: '0.0.2'
+        version: '0.0.3'
         repo_url: 'https://github.com/vlang/ui'
         vcs: 'git'
         tags: ['gui','user interface']


### PR DESCRIPTION
This brings the version number in `v.mod` and `ui.v` back in line with the README.