### PR TITLE
ci: set -skip-path for windows V build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         path: vlib/ui
     - name: Build V
       run: |
-        .\make.bat -msvc
+        .\make.bat -msvc -skip-path
     - name: Install dependencies
       run: |
         .\v.exe setup-freetype


### PR DESCRIPTION
@medvednikov this makes the windows pipeline pass too