### PR TITLE
ci: build users.v with -prod on all OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       run: |
         cd ./vlib/ui/examples/
         v run ./build_examples.vsh
+        v -prod users.v
 
   windows-msvc:
     runs-on: windows-latest
@@ -79,5 +80,6 @@ jobs:
         $env:path += ";$(get-location)"
         cd .\vlib\ui\examples\
         & v run .\build_examples.vsh
+        v -prod users.v
         echo "=========================="
         echo "v -showcc .\users.v"


### PR DESCRIPTION
I created this to catch things like https://github.com/vlang/v/pull/6178 more early.