### PR TITLE
group: unify children declaration

### DIFF
--- a/examples/group.v
+++ b/examples/group.v
@@ -1,7 +1,7 @@
 import ui
 
 const (
-	win_width = 300
+	win_width  = 300
 	win_height = 300
 )
 
@@ -9,11 +9,13 @@ struct App {
 mut:
 	window     &ui.Window
 	first_name string = ''
-	last_name string = ''
+	last_name  string = ''
 }
 
 fn main() {
-	mut app := &App{window: 0}
+	mut app := &App{
+		window: 0
+	}
 	app.window = ui.window({
 		width: win_width
 		height: win_height
@@ -21,38 +23,38 @@ fn main() {
 		state: app
 	}, [
 		ui.group({
-		    x:20
-		    y:20
+			x: 20
+			y: 20
 			title: 'Group Demo'
 		}, [
-			ui.textbox(
+			ui.textbox({
 				max_len: 20
 				width: 200
 				placeholder: 'First name'
 				text: &app.first_name
-			)
-			ui.textbox(
+			}),
+			ui.textbox({
 				max_len: 50
 				width: 200
 				placeholder: 'Last name'
 				text: &app.last_name
-			)
-			ui.checkbox(
+			}),
+			ui.checkbox({
 				checked: true
 				text: 'Online registration1'
-			)
-			ui.checkbox(
+			}),
+			ui.checkbox({
 				checked: true
 				text: 'Online registration2'
-			)
-			ui.checkbox(
+			}),
+			ui.checkbox({
 				checked: true
 				text: 'Online registration3'
-			)
-			ui.button(
+			}),
+			ui.button({
 				text: 'Add user'
-			)
-		])
+			}),
+		]),
 	])
 	ui.run(app.window)
 }

--- a/examples/group.v
+++ b/examples/group.v
@@ -24,36 +24,35 @@ fn main() {
 		    x:20
 		    y:20
 			title: 'Group Demo'
-			children: [
-				ui.textbox(
-					max_len: 20
-					width: 200
-					placeholder: 'First name'
-					text: &app.first_name
-				)
-				ui.textbox(
-					max_len: 50
-					width: 200
-					placeholder: 'Last name'
-					text: &app.last_name
-				)
-				ui.checkbox(
-					checked: true
-					text: 'Online registration1'
-				)
-				ui.checkbox(
-					checked: true
-					text: 'Online registration2'
-				)
-				ui.checkbox(
-					checked: true
-					text: 'Online registration3'
-				)
-				ui.button(
-					text: 'Add user'
-				)
-			]
-		})
+		}, [
+			ui.textbox(
+				max_len: 20
+				width: 200
+				placeholder: 'First name'
+				text: &app.first_name
+			)
+			ui.textbox(
+				max_len: 50
+				width: 200
+				placeholder: 'Last name'
+				text: &app.last_name
+			)
+			ui.checkbox(
+				checked: true
+				text: 'Online registration1'
+			)
+			ui.checkbox(
+				checked: true
+				text: 'Online registration2'
+			)
+			ui.checkbox(
+				checked: true
+				text: 'Online registration3'
+			)
+			ui.button(
+				text: 'Add user'
+			)
+		])
 	])
 	ui.run(app.window)
 }

--- a/group.v
+++ b/group.v
@@ -8,94 +8,91 @@ import eventbus
 
 pub struct Group {
 pub mut:
-
-    title          string
-    height         int
-    width          int
-    x              int
-    y              int
-    parent Layout
-    ui             &UI
-    children []Widget
-    margin_left int = 5
-    margin_top int = 10
-    margin_right int = 5
-    margin_bottom int = 5
-    spacing int = 5
+	title         string
+	height        int
+	width         int
+	x             int
+	y             int
+	parent        Layout
+	ui            &UI
+	children      []Widget
+	margin_left   int = 5
+	margin_top    int = 10
+	margin_right  int = 5
+	margin_bottom int = 5
+	spacing       int = 5
 }
 
 pub struct GroupConfig {
 pub mut:
-    title  string
-    x          int
-    y          int
-    width  int
-    height int
+	title  string
+	x      int
+	y      int
+	width  int
+	height int
 }
 
-fn (mut r Group)init(parent Layout) {
-    r.parent = parent
-    ui := parent.get_ui()
-    r.ui = ui
-
-    for child in r.children {
-        child.init(r)
-    }
-
-    mut widgets := r.children
-    mut start_x := r.x + r.margin_left
-    mut start_y := r.y + r.margin_top
-    for widget in widgets {
-        mut pw, ph := widget.size()
-        widget.set_pos(start_x, start_y)
-        start_y = start_y + ph + r.spacing
-        if pw > r.width - r.margin_left - r.margin_right {
-            r.width = pw + r.margin_left + r.margin_right
-        }
-        if start_y + r.margin_bottom > r.height {
-            r.height = start_y -ph
-        }
-    }
+fn (mut r Group) init(parent Layout) {
+	r.parent = parent
+	ui := parent.get_ui()
+	r.ui = ui
+	for child in r.children {
+		child.init(r)
+	}
+	mut widgets := r.children
+	mut start_x := r.x + r.margin_left
+	mut start_y := r.y + r.margin_top
+	for widget in widgets {
+		mut pw, ph := widget.size()
+		widget.set_pos(start_x, start_y)
+		start_y = start_y + ph + r.spacing
+		if pw > r.width - r.margin_left - r.margin_right {
+			r.width = pw + r.margin_left + r.margin_right
+		}
+		if start_y + r.margin_bottom > r.height {
+			r.height = start_y - ph
+		}
+	}
 }
 
 pub fn group(c GroupConfig, children []Widget) &Group {
-    mut cb := &Group{
-        title: c.title
-        x: c.x
-        y:c.y
-        width: c.width
-        height: c.height
-        children: children
+	mut cb := &Group{
+		title: c.title
+		x: c.x
+		y: c.y
+		width: c.width
+		height: c.height
+		children: children
 		ui: 0
-    }
-    return cb
+	}
+	return cb
 }
 
 fn (mut g Group) set_pos(x, y int) {
-    g.x = x
-    g.y = y
+	g.x = x
+	g.y = y
 }
 
 fn (mut g Group) propose_size(w, h int) (int, int) {
-    g.width = w
-    g.height = h
-    return g.width, g.height
+	g.width = w
+	g.height = h
+	return g.width, g.height
 }
 
 fn (mut b Group) draw() {
-    // Border
-    b.ui.gg.draw_empty_rect(b.x, b.y, b.width, b.height, gx.gray)
-    // Title
-    b.ui.gg.draw_rect(b.x + check_mark_size, b.y - 5, b.ui.gg.text_width(b.title) + 5, 10, default_window_color)
-    b.ui.gg.draw_text_def(b.x + check_mark_size + 3, b.y - 7, b.title)
-
-    for child in b.children {
-        child.draw()
-    }
+	// Border
+	b.ui.gg.draw_empty_rect(b.x, b.y, b.width, b.height, gx.gray)
+	// Title
+	b.ui.gg.draw_rect(b.x + check_mark_size, b.y - 5, b.ui.gg.text_width(b.title) + 5,
+		10, default_window_color)
+	b.ui.gg.draw_text_def(b.x + check_mark_size + 3, b.y - 7, b.title)
+	for child in b.children {
+		child.draw()
+	}
 }
 
 fn (t &Group) point_inside(x, y f64) bool {
-    return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
 }
 
 fn (mut b Group) focus() {
@@ -105,32 +102,32 @@ fn (mut b Group) unfocus() {
 }
 
 fn (t &Group) is_focused() bool {
-    return false
+	return false
 }
 
 fn (t &Group) get_ui() &UI {
-    return t.ui
+	return t.ui
 }
 
 fn (t &Group) unfocus_all() {
-    for child in t.children {
-        child.unfocus()
-    }
+	for child in t.children {
+		child.unfocus()
+	}
 }
 
 fn (t &Group) resize(width, height int) {
 }
 
 fn (t &Group) get_state() voidptr {
-    parent := t.parent
-    return parent.get_state()
+	parent := t.parent
+	return parent.get_state()
 }
 
 fn (b &Group) get_subscriber() &eventbus.Subscriber {
-    parent := b.parent
-    return parent.get_subscriber()
+	parent := b.parent
+	return parent.get_subscriber()
 }
 
 fn (c &Group) size() (int, int) {
-    return c.width, c.height
+	return c.width, c.height
 }

--- a/group.v
+++ b/group.v
@@ -31,7 +31,6 @@ pub mut:
     y          int
     width  int
     height int
-    children []Widget
 }
 
 fn (mut r Group)init(parent Layout) {
@@ -59,14 +58,14 @@ fn (mut r Group)init(parent Layout) {
     }
 }
 
-pub fn group(c GroupConfig) &Group {
+pub fn group(c GroupConfig, children []Widget) &Group {
     mut cb := &Group{
         title: c.title
         x: c.x
         y:c.y
         width: c.width
         height: c.height
-        children: c.children
+        children: children
 		ui: 0
     }
     return cb


### PR DESCRIPTION
This PR brings the way `group` children are declared in line with other widgets like `row`, `column`, `window`.
**Before**
```v
ui.group({
    children: []
})
```

**After**
```v
ui.group({}, [
    // children
])
```

I also vfmt'ed `group.v ` and `examples/group.v`.