### PR TITLE
Unify function argument names

### DIFF
--- a/button.v
+++ b/button.v
@@ -145,8 +145,8 @@ fn (mut b Button) draw() {
 
 //fn (b &Button) key_down(e KeyEvent) {}
 
-fn (t &Button) point_inside(x, y f64) bool {
-	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (b &Button) point_inside(x, y f64) bool {
+	return x >= b.x && x <= b.x + b.width && y >= b.y && y <= b.y + b.height
 }
 
 //fn (mut b Button) mouse_move(e MouseEvent) {}
@@ -160,6 +160,6 @@ fn (mut b Button) unfocus() {
 	b.state = .normal
 }
 
-fn (t &Button) is_focused() bool {
-	return t.is_focused
+fn (b &Button) is_focused() bool {
+	return b.is_focused
 }

--- a/canvas.v
+++ b/canvas.v
@@ -37,23 +37,23 @@ pub fn canvas(c CanvasConfig) &Canvas {
 	return canvas
 }
 
-fn (mut b Canvas) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut c Canvas) set_pos(x, y int) {
+	c.x = x
+	c.y = y
 }
 
-fn (mut b Canvas) size() (int, int) {
-	return b.width, b.height
+fn (mut c Canvas) size() (int, int) {
+	return c.width, c.height
 }
 
-fn (mut b Canvas) propose_size(w, h int) (int, int) {
-	/* b.width = w
-	b.height = h
+fn (mut c Canvas) propose_size(w, h int) (int, int) {
+	/* c.width = w
+	c.height = h
 	return w, h */
-	if b.width == 0 {
-		b.width = w
+	if c.width == 0 {
+		c.width = w
 	}
-	return b.width, b.height
+	return c.width, c.height
 }
 
 fn (c &Canvas) draw() {
@@ -64,14 +64,14 @@ fn (c &Canvas) draw() {
 	}
 }
 
-fn (t &Canvas) focus() {}
+fn (c &Canvas) focus() {}
 
-fn (t &Canvas) is_focused() bool {
+fn (c &Canvas) is_focused() bool {
 	return false
 }
 
-fn (t &Canvas) unfocus() {}
+fn (c &Canvas) unfocus() {}
 
-fn (t &Canvas) point_inside(x, y f64) bool {
-	return false // x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (c &Canvas) point_inside(x, y f64) bool {
+	return false // x >= c.x && x <= c.x + c.width && y >= c.y && y <= c.y + c.height
 }

--- a/checkbox.v
+++ b/checkbox.v
@@ -77,59 +77,59 @@ fn cb_click(mut cb CheckBox, e &MouseEvent, window &Window) {
 	}
 }
 
-fn (mut b CheckBox) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut cb CheckBox) set_pos(x, y int) {
+	cb.x = x
+	cb.y = y
 }
 
-fn (mut b CheckBox) size() (int,int) {
-	return b.width,b.height
+fn (mut cb CheckBox) size() (int,int) {
+	return cb.width,cb.height
 }
 
-fn (mut b CheckBox) propose_size(w, h int) (int,int) {
-	// b.width = w
-	// b.height = h
-	// width := check_mark_size + 5 + b.ui.ft.text_width(b.text)
-	return b.width,check_mark_size
+fn (mut cb CheckBox) propose_size(w, h int) (int,int) {
+	// cb.width = w
+	// cb.height = h
+	// width := check_mark_size + 5 + cb.ui.ft.text_width(cb.text)
+	return cb.width,check_mark_size
 }
 
-fn (mut b CheckBox) draw() {
-	b.ui.gg.draw_rect(b.x, b.y, check_mark_size, check_mark_size, gx.white) // progress_bar_color)
-	// b.ui.gg.draw_empty_rect(b.x, b.y, check_mark_size, check_mark_size, cb_border_color)
-	draw_inner_border(false, b.ui.gg, b.x, b.y, check_mark_size, check_mark_size, false)
+fn (mut cb CheckBox) draw() {
+	cb.ui.gg.draw_rect(cb.x, cb.y, check_mark_size, check_mark_size, gx.white) // progress_bar_color)
+	// cb.ui.gg.draw_empty_rect(cb.x, cb.y, check_mark_size, check_mark_size, cb_border_color)
+	draw_inner_border(false, cb.ui.gg, cb.x, cb.y, check_mark_size, check_mark_size, false)
 	// Draw X (TODO draw a check mark instead)
-	if b.checked {
-		b.ui.gg.draw_rect(b.x+3,b.y+3,2,2, gx.black)
+	if cb.checked {
+		cb.ui.gg.draw_rect(cb.x+3,cb.y+3,2,2, gx.black)
 		/*
-		x0 := b.x +2
-		y0 := b.y +2
-		b.ui.gg.draw_line_c(x0, y0, x0+check_mark_size -4, y0 + check_mark_size-4, gx.black)
-		b.ui.gg.draw_line_c(0.5+x0, y0, -3.5 +x0+check_mark_size , y0 + check_mark_size-4, gx.black)
+		x0 := cb.x +2
+		y0 := cb.y +2
+		cb.ui.gg.draw_line_c(x0, y0, x0+check_mark_size -4, y0 + check_mark_size-4, gx.black)
+		cb.ui.gg.draw_line_c(0.5+x0, y0, -3.5 +x0+check_mark_size , y0 + check_mark_size-4, gx.black)
 		//
-		y1 := b.y + check_mark_size - 2
-		b.ui.gg.draw_line_c(x0, y1, x0+check_mark_size -4, y0, gx.black)
-		b.ui.gg.draw_line_c(0.5+x0, y1, -3.5+x0+check_mark_size, y0, gx.black)
+		y1 := cb.y + check_mark_size - 2
+		cb.ui.gg.draw_line_c(x0, y1, x0+check_mark_size -4, y0, gx.black)
+		cb.ui.gg.draw_line_c(0.5+x0, y1, -3.5+x0+check_mark_size, y0, gx.black)
 		*/
-		b.ui.gg.draw_image(b.x + 3, b.y + 3, 8, 8, b.ui.cb_image)
+		cb.ui.gg.draw_image(cb.x + 3, cb.y + 3, 8, 8, cb.ui.cb_image)
 	}
 	// Text
-	b.ui.gg.draw_text(b.x + check_mark_size + 5, b.y, b.text, btn_text_cfg)
+	cb.ui.gg.draw_text(cb.x + check_mark_size + 5, cb.y, cb.text, btn_text_cfg)
 }
 
-fn (t &CheckBox) point_inside(x, y f64) bool {
-	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (cb &CheckBox) point_inside(x, y f64) bool {
+	return x >= cb.x && x <= cb.x + cb.width && y >= cb.y && y <= cb.y + cb.height
 }
 
-fn (mut b CheckBox) mouse_move(e MouseEvent) {}
+fn (mut cb CheckBox) mouse_move(e MouseEvent) {}
 
-fn (mut b CheckBox) focus() {
-	b.is_focused = true
+fn (mut cb CheckBox) focus() {
+	cb.is_focused = true
 }
 
-fn (mut b CheckBox) unfocus() {
-	b.is_focused = false
+fn (mut cb CheckBox) unfocus() {
+	cb.is_focused = false
 }
 
-fn (t &CheckBox) is_focused() bool {
-	return t.is_focused
+fn (cb &CheckBox) is_focused() bool {
+	return cb.is_focused
 }

--- a/dropdown.v
+++ b/dropdown.v
@@ -75,13 +75,13 @@ fn (mut dd Dropdown) set_pos(x, y int) {
 	dd.y = y
 }
 
-fn (mut b Dropdown) size() (int, int) {
-	return b.width, dropdown_height
+fn (mut dd Dropdown) size() (int, int) {
+	return dd.width, dropdown_height
 }
 
 fn (mut dd Dropdown) propose_size(w, h int) (int, int) {
 	dd.width = w
-	//b.height = h
+	//dd.height = h
 	return w, dropdown_height
 }
 

--- a/group.v
+++ b/group.v
@@ -32,25 +32,25 @@ pub mut:
 	height int
 }
 
-fn (mut r Group) init(parent Layout) {
-	r.parent = parent
+fn (mut g Group) init(parent Layout) {
+	g.parent = parent
 	ui := parent.get_ui()
-	r.ui = ui
-	for child in r.children {
-		child.init(r)
+	g.ui = ui
+	for child in g.children {
+		child.init(g)
 	}
-	mut widgets := r.children
-	mut start_x := r.x + r.margin_left
-	mut start_y := r.y + r.margin_top
+	mut widgets := g.children
+	mut start_x := g.x + g.margin_left
+	mut start_y := g.y + g.margin_top
 	for widget in widgets {
 		mut pw, ph := widget.size()
 		widget.set_pos(start_x, start_y)
-		start_y = start_y + ph + r.spacing
-		if pw > r.width - r.margin_left - r.margin_right {
-			r.width = pw + r.margin_left + r.margin_right
+		start_y = start_y + ph + g.spacing
+		if pw > g.width - g.margin_left - g.margin_right {
+			g.width = pw + g.margin_left + g.margin_right
 		}
-		if start_y + r.margin_bottom > r.height {
-			r.height = start_y - ph
+		if start_y + g.margin_bottom > g.height {
+			g.height = start_y - ph
 		}
 	}
 }
@@ -79,55 +79,55 @@ fn (mut g Group) propose_size(w, h int) (int, int) {
 	return g.width, g.height
 }
 
-fn (mut b Group) draw() {
+fn (mut g Group) draw() {
 	// Border
-	b.ui.gg.draw_empty_rect(b.x, b.y, b.width, b.height, gx.gray)
+	g.ui.gg.draw_empty_rect(g.x, g.y, g.width, g.height, gx.gray)
 	// Title
-	b.ui.gg.draw_rect(b.x + check_mark_size, b.y - 5, b.ui.gg.text_width(b.title) + 5,
+	g.ui.gg.draw_rect(g.x + check_mark_size, g.y - 5, g.ui.gg.text_width(g.title) + 5,
 		10, default_window_color)
-	b.ui.gg.draw_text_def(b.x + check_mark_size + 3, b.y - 7, b.title)
-	for child in b.children {
+	g.ui.gg.draw_text_def(g.x + check_mark_size + 3, g.y - 7, g.title)
+	for child in g.children {
 		child.draw()
 	}
 }
 
-fn (t &Group) point_inside(x, y f64) bool {
-	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (g &Group) point_inside(x, y f64) bool {
+	return x >= g.x && x <= g.x + g.width && y >= g.y && y <= g.y + g.height
 }
 
-fn (mut b Group) focus() {
+fn (mut g Group) focus() {
 }
 
-fn (mut b Group) unfocus() {
+fn (mut g Group) unfocus() {
 }
 
-fn (t &Group) is_focused() bool {
+fn (g &Group) is_focused() bool {
 	return false
 }
 
-fn (t &Group) get_ui() &UI {
-	return t.ui
+fn (g &Group) get_ui() &UI {
+	return g.ui
 }
 
-fn (t &Group) unfocus_all() {
-	for child in t.children {
+fn (g &Group) unfocus_all() {
+	for child in g.children {
 		child.unfocus()
 	}
 }
 
-fn (t &Group) resize(width, height int) {
+fn (g &Group) resize(width, height int) {
 }
 
-fn (t &Group) get_state() voidptr {
-	parent := t.parent
+fn (g &Group) get_state() voidptr {
+	parent := g.parent
 	return parent.get_state()
 }
 
-fn (b &Group) get_subscriber() &eventbus.Subscriber {
-	parent := b.parent
+fn (g &Group) get_subscriber() &eventbus.Subscriber {
+	parent := g.parent
 	return parent.get_subscriber()
 }
 
-fn (c &Group) size() (int, int) {
-	return c.width, c.height
+fn (g &Group) size() (int, int) {
+	return g.width, g.height
 }

--- a/label.v
+++ b/label.v
@@ -30,45 +30,45 @@ pub fn label(c LabelConfig) &Label {
 	return lbl
 }
 
-fn (mut b Label) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut l Label) set_pos(x, y int) {
+	l.x = x
+	l.y = y
 }
 
-fn (mut b Label) size() (int, int) {
-	w,h := b.ui.gg.text_size(b.text)
+fn (mut l Label) size() (int, int) {
+	w,h := l.ui.gg.text_size(l.text)
 
 	// First return the width, then the height multiplied by line count.
-	return w, h * b.text.split('\n').len
+	return w, h * l.text.split('\n').len
 }
 
-fn (mut b Label) propose_size(w, h int) (int, int) {
-	ww,hh := b.ui.gg.text_size(b.text)
+fn (mut l Label) propose_size(w, h int) (int, int) {
+	ww,hh := l.ui.gg.text_size(l.text)
 
 	// First return the width, then the height multiplied by line count.
-	return ww, hh * b.text.split('\n').len
+	return ww, hh * l.text.split('\n').len
 }
 
-fn (mut b Label) draw() {
-	splits := b.text.split('\n') // Split the text into an array of lines.
-	height := b.ui.gg.text_height('W') // Get the height of the current font.
+fn (mut l Label) draw() {
+	splits := l.text.split('\n') // Split the text into an array of lines.
+	height := l.ui.gg.text_height('W') // Get the height of the current font.
 
 	for i, split in splits {
-		// Draw the text at b.x and b.y + line height * current line
-		b.ui.gg.draw_text(b.x, b.y + (height * i), split, btn_text_cfg)
+		// Draw the text at l.x and l.y + line height * current line
+		l.ui.gg.draw_text(l.x, l.y + (height * i), split, btn_text_cfg)
 	}
 }
 
-fn (t &Label) focus() {}
+fn (l &Label) focus() {}
 
-fn (t &Label) is_focused() bool {
+fn (l &Label) is_focused() bool {
 	return false
 }
 
-fn (t &Label) unfocus() {}
+fn (l &Label) unfocus() {}
 
-fn (t &Label) point_inside(x, y f64) bool {
-	return false // x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (l &Label) point_inside(x, y f64) bool {
+	return false // x >= l.x && x <= l.x + l.width && y >= l.y && y <= l.y + l.height
 }
 
 pub fn (mut l Label) set_text(s string) {

--- a/listbox.v
+++ b/listbox.v
@@ -273,52 +273,52 @@ fn on_key_up(mut lb ListBox, e &KeyEvent, window &Window ) {
     }
 }
 
-fn (mut list ListBox) set_pos(x, y int) {
-    list.x = x
-    list.y = y
+fn (mut lb ListBox) set_pos(x, y int) {
+    lb.x = x
+    lb.y = y
 }
 
-fn (mut list ListBox) focus() {
-    list.focused = true
+fn (mut lb ListBox) focus() {
+    lb.focused = true
 }
 
-fn (mut list ListBox) unfocus() {
-    list.focused = false
+fn (mut lb ListBox) unfocus() {
+    lb.focused = false
 }
 
-fn (list &ListBox) is_focused() bool {
-    return list.focused
+fn (lb &ListBox) is_focused() bool {
+    return lb.focused
 }
 
-fn (list &ListBox) get_ui() &UI {
-    return list.ui
+fn (lb &ListBox) get_ui() &UI {
+    return lb.ui
 }
 
-fn (mut list ListBox) unfocus_all() {
-    list.focused = false
+fn (mut lb ListBox) unfocus_all() {
+    lb.focused = false
 }
 
-fn (mut list ListBox) resize(width, height int) {
-    list.width = width
-    list.height = height
-    list.draw_count = list.height / list.item_height
+fn (mut lb ListBox) resize(width, height int) {
+    lb.width = width
+    lb.height = height
+    lb.draw_count = lb.height / lb.item_height
 }
 
-fn (list &ListBox) get_state() voidptr {
-    parent := list.parent
+fn (lb &ListBox) get_state() voidptr {
+    parent := lb.parent
     return parent.get_state()
 }
 
-fn (list &ListBox) get_subscriber() &eventbus.Subscriber {
-    parent := list.parent
+fn (lb &ListBox) get_subscriber() &eventbus.Subscriber {
+    parent := lb.parent
     return parent.get_subscriber()
 }
 
-fn (list &ListBox) size() (int, int) {
-    return list.width, list.height
+fn (lb &ListBox) size() (int, int) {
+    return lb.width, lb.height
 }
 
-fn (mut list ListBox) propose_size(w, h int) (int, int) {
-    list.resize(w, h)
-    return list.width, list.height
+fn (mut lb ListBox) propose_size(w, h int) (int, int) {
+    lb.resize(w, h)
+    return lb.width, lb.height
 }

--- a/menu.v
+++ b/menu.v
@@ -47,18 +47,18 @@ pub fn menu(c MenuConfig) &Menu {
 	}
 }
 
-fn (mut b Menu) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut m Menu) set_pos(x, y int) {
+	m.x = x
+	m.y = y
 }
 
-fn (mut b Menu) size() (int, int) {
+fn (mut m Menu) size() (int, int) {
 	return 0, 0
 }
 
-fn (mut b Menu) propose_size(w, h int) (int, int) {
-	//b.width = w
-	//b.height = h
+fn (mut m Menu) propose_size(w, h int) (int, int) {
+	//m.width = w
+	//m.height = h
 	return 0,0
 }
 
@@ -79,18 +79,18 @@ pub fn (mut m Menu) add_item(text string, action MenuFn) {
 
 }
 
-fn (t &Menu) focus() {}
+fn (m &Menu) focus() {}
 
-fn (t &Menu) is_focused() bool {
+fn (m &Menu) is_focused() bool {
 	return false
 }
 
-fn (t &Menu) unfocus() {}
+fn (m &Menu) unfocus() {}
 
-fn (t &Menu) point_inside(x, y f64) bool {
-	return false // x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (m &Menu) point_inside(x, y f64) bool {
+	return false // x >= m.x && x <= m.x + m.width && y >= m.y && y <= m.y + m.height
 }
 
-pub fn (mut l Menu) set_text(s string) {
-	l.text = s
+pub fn (mut m Menu) set_text(s string) {
+	m.text = s
 }

--- a/picture.v
+++ b/picture.v
@@ -89,35 +89,35 @@ fn pic_click(mut pic Picture, e &MouseEvent, window &Window) {
 	}
 }
 
-fn (mut b Picture) set_pos(x, y int) {
-	b.x = x + b.offset_x
-	b.y = y + b.offset_y
+fn (mut pic Picture) set_pos(x, y int) {
+	pic.x = x + pic.offset_x
+	pic.y = y + pic.offset_y
 }
 
-fn (mut b Picture) size() (int, int) {
-	return b.width, b.height
+fn (mut pic Picture) size() (int, int) {
+	return pic.width, pic.height
 }
 
-fn (mut b Picture) propose_size(w, h int) (int, int) {
-	// b.width = w
-	// b.height = h
-	return b.width, b.height
+fn (mut pic Picture) propose_size(w, h int) (int, int) {
+	// pic.width = w
+	// pic.height = h
+	return pic.width, pic.height
 }
 
-fn (mut b Picture) draw() {
-	b.ui.gg.draw_image(b.x, b.y, b.width, b.height, b.image)
+fn (mut pic Picture) draw() {
+	pic.ui.gg.draw_image(pic.x, pic.y, pic.width, pic.height, pic.image)
 }
 
-fn (t &Picture) focus() {
+fn (pic &Picture) focus() {
 }
 
-fn (t &Picture) is_focused() bool {
+fn (pic &Picture) is_focused() bool {
 	return false
 }
 
-fn (t &Picture) unfocus() {
+fn (pic &Picture) unfocus() {
 }
 
-fn (t &Picture) point_inside(x, y f64) bool {
-	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (pic &Picture) point_inside(x, y f64) bool {
+	return x >= pic.x && x <= pic.x + pic.width && y >= pic.y && y <= pic.y + pic.height
 }

--- a/progressbar.v
+++ b/progressbar.v
@@ -42,7 +42,7 @@ fn (mut pb ProgressBar)init(parent Layout) {
 }
 
 pub fn progressbar(c ProgressBarConfig) &ProgressBar {
-	mut p := &ProgressBar{
+	mut pb := &ProgressBar{
 		height: c.height
 		width: c.width
 		min: c.min
@@ -50,48 +50,48 @@ pub fn progressbar(c ProgressBarConfig) &ProgressBar {
 		val: c.val
 		ui: 0
 	}
-	return p
+	return pb
 }
 
-fn (mut b ProgressBar) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut pb ProgressBar) set_pos(x, y int) {
+	pb.x = x
+	pb.y = y
 }
 
-fn (mut b ProgressBar) size() (int, int) {
-	return b.width, b.height
+fn (mut pb ProgressBar) size() (int, int) {
+	return pb.width, pb.height
 }
 
-fn (mut b ProgressBar) propose_size(w, h int) (int, int) {
-	/* b.width = w
-	b.height = h
+fn (mut pb ProgressBar) propose_size(w, h int) (int, int) {
+	/* pb.width = w
+	pb.height = h
 	return w, h */
-	if b.width == 0 {
-		b.width = w
+	if pb.width == 0 {
+		pb.width = w
 	}
-	return b.width, b.height
+	return pb.width, pb.height
 }
 
-fn (b &ProgressBar) draw() {
+fn (pb &ProgressBar) draw() {
 	// Draw the gray background
-	b.ui.gg.draw_rect(b.x, b.y, b.width, b.height, progress_bar_background_color)
-	b.ui.gg.draw_empty_rect(b.x, b.y, b.width, b.height, progress_bar_background_border_color)
+	pb.ui.gg.draw_rect(pb.x, pb.y, pb.width, pb.height, progress_bar_background_color)
+	pb.ui.gg.draw_empty_rect(pb.x, pb.y, pb.width, pb.height, progress_bar_background_border_color)
 	// Draw the value
-	width := int(f64(b.width) * (f64(b.val) / f64(b.max)))
-	b.ui.gg.draw_empty_rect(b.x, b.y, width, b.height, progress_bar_border_color) // gx.Black)
-	b.ui.gg.draw_rect(b.x, b.y, width, b.height, progress_bar_color) // gx.Black)
+	width := int(f64(pb.width) * (f64(pb.val) / f64(pb.max)))
+	pb.ui.gg.draw_empty_rect(pb.x, pb.y, width, pb.height, progress_bar_border_color) // gx.Black)
+	pb.ui.gg.draw_rect(pb.x, pb.y, width, pb.height, progress_bar_color) // gx.Black)
 }
 
-fn (t &ProgressBar) point_inside(x, y f64) bool {
-	return false//x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (pb &ProgressBar) point_inside(x, y f64) bool {
+	return false//x >= pb.x && x <= pb.x + pb.width && y >= pb.y && y <= pb.y + pb.height
 }
 
-fn (b &ProgressBar) focus() {
+fn (pb &ProgressBar) focus() {
 }
 
-fn (t &ProgressBar) is_focused() bool {
-	return t.is_focused
+fn (pb &ProgressBar) is_focused() bool {
+	return pb.is_focused
 }
 
-fn (b &ProgressBar) unfocus() {
+fn (pb &ProgressBar) unfocus() {
 }

--- a/radio.v
+++ b/radio.v
@@ -61,7 +61,7 @@ fn (mut r Radio)init(parent Layout) {
 }
 
 pub fn radio(c RadioConfig) &Radio {
-	mut cb := &Radio{
+	mut r := &Radio{
 		height: 20
 		values: c.values
 		title: c.title
@@ -72,51 +72,51 @@ pub fn radio(c RadioConfig) &Radio {
 	/*
 	if c.ref != 0 {
 		mut ref := c.ref
-		*ref = *cb
+		*ref = *r
 		return &ref
 	}
 	*/
-	return cb
+	return r
 
 }
 
-fn (mut b Radio) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut r Radio) set_pos(x, y int) {
+	r.x = x
+	r.y = y
 }
 
-fn (mut b Radio) size() (int, int) {
-	return b.width, b.height
+fn (mut r Radio) size() (int, int) {
+	return r.width, r.height
 }
 
-fn (mut cb Radio) propose_size(w, h int) (int, int) {
-	//b.width = w
-	//b.height = 20//default_font_size
-	return cb.width, cb.values.len * (cb.height + 5)
+fn (mut r Radio) propose_size(w, h int) (int, int) {
+	//r.width = w
+	//r.height = 20//default_font_size
+	return r.width, r.values.len * (r.height + 5)
 }
 
-fn (mut b Radio) draw() {
+fn (mut r Radio) draw() {
 	// Border
-	b.ui.gg.draw_empty_rect(b.x, b.y, b.width, b.values.len * (b.height + 5), gx.gray)
+	r.ui.gg.draw_empty_rect(r.x, r.y, r.width, r.values.len * (r.height + 5), gx.gray)
 	// Title
-	b.ui.gg.draw_rect(b.x + check_mark_size, b.y - 5, b.ui.gg.text_width(b.title) + 5, 10, default_window_color)
-	b.ui.gg.draw_text_def(b.x + check_mark_size + 3, b.y - 7, b.title)
+	r.ui.gg.draw_rect(r.x + check_mark_size, r.y - 5, r.ui.gg.text_width(r.title) + 5, 10, default_window_color)
+	r.ui.gg.draw_text_def(r.x + check_mark_size + 3, r.y - 7, r.title)
 	// Values
-	for i, val in b.values {
-		y := b.y + b.height * i + 15
-		x := b.x + 5
-		b.ui.gg.draw_image(x, y-1, 16, 16, b.ui.selected_radio_image)
-		if i != b.selected_index {
-			b.ui.gg.draw_rect(x+4,y+3,8,8,gx.white) // hide the black circle
-			//b.ui.gg.draw_image(x, y-3, 16, 16, b.ui.circle_image)
+	for i, val in r.values {
+		y := r.y + r.height * i + 15
+		x := r.x + 5
+		r.ui.gg.draw_image(x, y-1, 16, 16, r.ui.selected_radio_image)
+		if i != r.selected_index {
+			r.ui.gg.draw_rect(x+4,y+3,8,8,gx.white) // hide the black circle
+			//r.ui.gg.draw_image(x, y-3, 16, 16, r.ui.circle_image)
 		}
 		// Text
-		b.ui.gg.draw_text(b.x + check_mark_size + 10, y, val, btn_text_cfg)
+		r.ui.gg.draw_text(r.x + check_mark_size + 10, y, val, btn_text_cfg)
 	}
 }
 
-fn (t &Radio) point_inside(x, y f64) bool {
-	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + (t.height + 5) * t.values.len
+fn (r &Radio) point_inside(x, y f64) bool {
+	return x >= r.x && x <= r.x + r.width && y >= r.y && y <= r.y + (r.height + 5) * r.values.len
 }
 
 fn radio_click(mut r Radio, e &MouseEvent, zzz voidptr) {
@@ -132,18 +132,18 @@ fn radio_click(mut r Radio, e &MouseEvent, zzz voidptr) {
 	//println(r.selected_index)
 }
 
-fn (mut b Radio) focus() {
-	b.is_focused = true
+fn (mut r Radio) focus() {
+	r.is_focused = true
 }
 
-fn (mut b Radio) unfocus() {
-	b.is_focused = false
+fn (mut r Radio) unfocus() {
+	r.is_focused = false
 }
 
 pub fn (r &Radio) selected_value() string {
 	return r.values[r.selected_index]
 }
 
-fn (t &Radio) is_focused() bool {
-	return t.is_focused
+fn (r &Radio) is_focused() bool {
+	return r.is_focused
 }

--- a/rectangle.v
+++ b/rectangle.v
@@ -64,8 +64,8 @@ fn (mut r Rectangle) set_pos(x, y int) {
 	r.y = y
 }
 
-fn (mut b Rectangle) size() (int,int) {
-	return b.width,b.height
+fn (mut r Rectangle) size() (int,int) {
+	return r.width,r.height
 }
 
 fn (mut r Rectangle) propose_size(w, h int) (int,int) {

--- a/slider.v
+++ b/slider.v
@@ -65,7 +65,7 @@ fn (mut s Slider) init(parent Layout) {
 }
 
 pub fn slider(c SliderConfig) &Slider {
-	mut p := &Slider{
+	mut s := &Slider{
 		track_height: c.height
 		track_width: c.width
 		min: c.min
@@ -80,29 +80,29 @@ pub fn slider(c SliderConfig) &Slider {
 		ui: 0
 	}
 	if !c.thumb_in_track {
-		p.thumb_height = if p.orientation == .horizontal { p.track_height + 10 } else { 10 }
-		p.thumb_width = if p.orientation == .horizontal { 10 } else { p.track_width + 10 }
+		s.thumb_height = if s.orientation == .horizontal { s.track_height + 10 } else { 10 }
+		s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width + 10 }
 	}
 	else {
-		p.thumb_height = if p.orientation == .horizontal { p.track_height - 3 } else { 10 }
-		p.thumb_width = if p.orientation == .horizontal { 10 } else { p.track_width - 3 }
+		s.thumb_height = if s.orientation == .horizontal { s.track_height - 3 } else { 10 }
+		s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width - 3 }
 	}
-	if p.min > p.max {
-		tmp := p.max
-		p.max = p.min
-		p.min = tmp
+	if s.min > s.max {
+		tmp := s.max
+		s.max = s.min
+		s.min = tmp
 	}
-	return p
+	return s
 }
 
-fn (b &Slider) draw_thumb() {
-	axis := if b.orientation == .horizontal { b.x } else { b.y }
-	rev_axis := if b.orientation == .horizontal { b.y } else { b.x }
-	rev_dim := if b.orientation == .horizontal { b.track_height } else { b.track_width }
-	rev_thumb_dim := if b.orientation == .horizontal { b.thumb_height } else { b.thumb_width }
-	dim := if b.orientation == .horizontal { b.track_width } else { b.track_height }
-	mut pos := f32(dim) * ((b.val - f32(b.min)) / f32(b.max - b.min))
-	if b.rev_min_max_pos {
+fn (s &Slider) draw_thumb() {
+	axis := if s.orientation == .horizontal { s.x } else { s.y }
+	rev_axis := if s.orientation == .horizontal { s.y } else { s.x }
+	rev_dim := if s.orientation == .horizontal { s.track_height } else { s.track_width }
+	rev_thumb_dim := if s.orientation == .horizontal { s.thumb_height } else { s.thumb_width }
+	dim := if s.orientation == .horizontal { s.track_width } else { s.track_height }
+	mut pos := f32(dim) * ((s.val - f32(s.min)) / f32(s.max - s.min))
+	if s.rev_min_max_pos {
 		pos = -pos + f32(dim)
 	}
 	pos += f32(axis)
@@ -113,170 +113,170 @@ fn (b &Slider) draw_thumb() {
 		pos = f32(axis)
 	}
 	middle := f32(rev_axis) - (f32(rev_thumb_dim - rev_dim) / 2)
-	if b.orientation == .horizontal {
-		b.ui.gg.draw_rect(pos - f32(b.thumb_width) / 2, middle, b.thumb_width, b.thumb_height, thumb_color)
+	if s.orientation == .horizontal {
+		s.ui.gg.draw_rect(pos - f32(s.thumb_width) / 2, middle, s.thumb_width, s.thumb_height, thumb_color)
 	}
 	else {
-		b.ui.gg.draw_rect(middle, pos - f32(b.thumb_height) / 2, b.thumb_width, b.thumb_height, thumb_color)
+		s.ui.gg.draw_rect(middle, pos - f32(s.thumb_height) / 2, s.thumb_width, s.thumb_height, thumb_color)
 	}
 }
 
-fn (mut b Slider) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut s Slider) set_pos(x, y int) {
+	s.x = x
+	s.y = y
 }
 
-fn (mut b Slider) size() (int,int) {
-	if b.orientation == .horizontal {
-		return b.track_width,b.thumb_height
+fn (mut s Slider) size() (int,int) {
+	if s.orientation == .horizontal {
+		return s.track_width,s.thumb_height
 	}
 	else {
-		return b.thumb_width,b.track_height
+		return s.thumb_width,s.track_height
 	}
 }
 
-fn (mut b Slider) propose_size(w, h int) (int,int) {
-	/* p.track_width = w
-	p.track_height = h
-	if p.track_height > 20 {p.track_height = 20} //TODO constrain
-	p.thumb_height = if p.orientation == .horizontal {p.track_height + 10} else {10}
-	p.thumb_width = if p.orientation == .horizontal { 10 } else {p.track_width + 10}
-	return w, p.thumb_height */
-	if b.orientation == .horizontal {
-		return b.track_width,b.thumb_height
+fn (mut s Slider) propose_size(w, h int) (int,int) {
+	/* s.track_width = w
+	s.track_height = h
+	if s.track_height > 20 {s.track_height = 20} //TODO constrain
+	s.thumb_height = if s.orientation == .horizontal {s.track_height + 10} else {10}
+	s.thumb_width = if s.orientation == .horizontal { 10 } else {s.track_width + 10}
+	return w, s.thumb_height */
+	if s.orientation == .horizontal {
+		return s.track_width,s.thumb_height
 	}
 	else {
-		return b.thumb_width,b.track_height
+		return s.thumb_width,s.track_height
 	}
 }
 
-fn (b &Slider) draw() {
+fn (s &Slider) draw() {
 	// Draw the track
-	b.ui.gg.draw_rect(b.x, b.y, b.track_width, b.track_height, slider_background_color)
-	if b.track_line_displayed {
-		if b.orientation == .horizontal {
-			b.ui.gg.draw_line(b.x + 2, b.y + b.track_height / 2, b.x + b.track_width - 4, b.y + b.track_height / 2, gx.rgb(0, 0, 0))
+	s.ui.gg.draw_rect(s.x, s.y, s.track_width, s.track_height, slider_background_color)
+	if s.track_line_displayed {
+		if s.orientation == .horizontal {
+			s.ui.gg.draw_line(s.x + 2, s.y + s.track_height / 2, s.x + s.track_width - 4, s.y + s.track_height / 2, gx.rgb(0, 0, 0))
 		}
 		else {
-			b.ui.gg.draw_line(b.x + b.track_width / 2, b.y + 2, b.x + b.track_width / 2, b.y + b.track_height - 4, gx.rgb(0, 0, 0))
+			s.ui.gg.draw_line(s.x + s.track_width / 2, s.y + 2, s.x + s.track_width / 2, s.y + s.track_height - 4, gx.rgb(0, 0, 0))
 		}
 	}
-	if !b.is_focused {
-		b.ui.gg.draw_empty_rect(b.x, b.y, b.track_width, b.track_height, slider_background_border_color)
+	if !s.is_focused {
+		s.ui.gg.draw_empty_rect(s.x, s.y, s.track_width, s.track_height, slider_background_border_color)
 	}
 	else {
-		b.ui.gg.draw_empty_rect(b.x, b.y, b.track_width, b.track_height, slider_focused_background_border_color)
+		s.ui.gg.draw_empty_rect(s.x, s.y, s.track_width, s.track_height, slider_focused_background_border_color)
 	}
 	// Draw the thumb
-	b.draw_thumb()
+	s.draw_thumb()
 }
 
-fn slider_key_down(mut b Slider, e &KeyEvent, zzz voidptr) {
-	if !b.is_focused {
+fn slider_key_down(mut s Slider, e &KeyEvent, zzz voidptr) {
+	if !s.is_focused {
 		return
 	}
 	match e.key {
 		.up, .left {
-			if !b.rev_min_max_pos {
-				if int(b.val) > b.min {
-					b.val--
+			if !s.rev_min_max_pos {
+				if int(s.val) > s.min {
+					s.val--
 				}
 			}
 			else {
-				if int(b.val) < b.max {
-					b.val++
+				if int(s.val) < s.max {
+					s.val++
 				}
 			}
 		}
 		.down, .right {
-			if !b.rev_min_max_pos {
-				if int(b.val) < b.max {
-					b.val++
+			if !s.rev_min_max_pos {
+				if int(s.val) < s.max {
+					s.val++
 				}
 			}
 			else {
-				if int(b.val) > b.min {
-					b.val--
+				if int(s.val) > s.min {
+					s.val--
 				}
 			}
 		}
 		else {}
 	}
-	if b.on_value_changed != voidptr(0) {
-		parent := b.parent
+	if s.on_value_changed != voidptr(0) {
+		parent := s.parent
 		state := parent.get_state()
-		b.on_value_changed(state, b)
+		s.on_value_changed(state, s)
 	}
 }
 
-fn (t &Slider) point_inside(x, y f64) bool {
-	return x >= t.x && x <= t.x + t.track_width && y >= t.y && y <= t.y + t.track_height
+fn (s &Slider) point_inside(x, y f64) bool {
+	return x >= s.x && x <= s.x + s.track_width && y >= s.y && y <= s.y + s.track_height
 }
 
-fn slider_click(mut b Slider, e &MouseEvent, zzz voidptr) {
-	if !b.point_inside_thumb(e.x, e.y) && (!b.point_inside(e.x, e.y) || b.focus_on_thumb_only) {
-		b.dragging = false
-		b.is_focused = false
+fn slider_click(mut s Slider, e &MouseEvent, zzz voidptr) {
+	if !s.point_inside_thumb(e.x, e.y) && (!s.point_inside(e.x, e.y) || s.focus_on_thumb_only) {
+		s.dragging = false
+		s.is_focused = false
 		return
 	}
-	if !b.focus_on_thumb_only {
-		b.change_value(e.x, e.y)
+	if !s.focus_on_thumb_only {
+		s.change_value(e.x, e.y)
 	}
-	b.is_focused = true
-	b.dragging = e.action == 1
+	s.is_focused = true
+	s.dragging = e.action == 1
 }
 
-fn slider_mouse_move(mut b Slider, e &MouseEvent, zzz voidptr) {
-	if b.dragging {
-		b.change_value(e.x, e.y)
+fn slider_mouse_move(mut s Slider, e &MouseEvent, zzz voidptr) {
+	if s.dragging {
+		s.change_value(e.x, e.y)
 	}
 }
 
-fn (mut b Slider) change_value(x, y int) {
-	dim := if b.orientation == .horizontal { b.track_width } else { b.track_height }
-	axis := if b.orientation == .horizontal { b.x } else { b.y }
+fn (mut s Slider) change_value(x, y int) {
+	dim := if s.orientation == .horizontal { s.track_width } else { s.track_height }
+	axis := if s.orientation == .horizontal { s.x } else { s.y }
 	// TODO parser bug ` - axis`
-	mut pos := if b.orientation == .horizontal { x } else { y }
+	mut pos := if s.orientation == .horizontal { x } else { y }
 	pos -= axis
-	if b.rev_min_max_pos {
+	if s.rev_min_max_pos {
 		pos = -pos + dim
 	}
-	b.val = f32(b.min) + (f32(pos) * f32(b.max - b.min)) / f32(dim)
-	if int(b.val) < b.min {
-		b.val = f32(b.min)
+	s.val = f32(s.min) + (f32(pos) * f32(s.max - s.min)) / f32(dim)
+	if int(s.val) < s.min {
+		s.val = f32(s.min)
 	}
-	else if int(b.val) > b.max {
-		b.val = f32(b.max)
+	else if int(s.val) > s.max {
+		s.val = f32(s.max)
 	}
-	if b.on_value_changed != voidptr(0) {
-		parent := b.parent
+	if s.on_value_changed != voidptr(0) {
+		parent := s.parent
 		state := parent.get_state()
-		b.on_value_changed(state, b)
+		s.on_value_changed(state, s)
 	}
 }
 
-fn (mut b Slider) focus() {
-	parent := b.parent
+fn (mut s Slider) focus() {
+	parent := s.parent
 	parent.unfocus_all()
-	b.is_focused = true
+	s.is_focused = true
 }
 
-fn (t &Slider) is_focused() bool {
-	return t.is_focused
+fn (s &Slider) is_focused() bool {
+	return s.is_focused
 }
 
-fn (mut b Slider) unfocus() {
-	b.is_focused = false
+fn (mut s Slider) unfocus() {
+	s.is_focused = false
 }
 
-fn (t &Slider) point_inside_thumb(x, y f64) bool {
-	axis := if t.orientation == .horizontal { t.x } else { t.y }
-	rev_axis := if t.orientation == .horizontal { t.y } else { t.x }
-	rev_dim := if t.orientation == .horizontal { t.track_height } else { t.track_width }
-	rev_thumb_dim := if t.orientation == .horizontal { t.thumb_height } else { t.thumb_width }
-	dim := if t.orientation == .horizontal { t.track_width } else { t.track_height }
-	mut pos := f32(dim) * ((t.val - f32(t.min)) / f32(t.max - t.min))
-	if t.rev_min_max_pos {
+fn (s &Slider) point_inside_thumb(x, y f64) bool {
+	axis := if s.orientation == .horizontal { s.x } else { s.y }
+	rev_axis := if s.orientation == .horizontal { s.y } else { s.x }
+	rev_dim := if s.orientation == .horizontal { s.track_height } else { s.track_width }
+	rev_thumb_dim := if s.orientation == .horizontal { s.thumb_height } else { s.thumb_width }
+	dim := if s.orientation == .horizontal { s.track_width } else { s.track_height }
+	mut pos := f32(dim) * ((s.val - f32(s.min)) / f32(s.max - s.min))
+	if s.rev_min_max_pos {
 		pos = -pos + f32(dim)
 	}
 	pos += f32(axis)
@@ -287,14 +287,14 @@ fn (t &Slider) point_inside_thumb(x, y f64) bool {
 		pos = f32(axis)
 	}
 	middle := f32(rev_axis) - (f32(rev_thumb_dim - rev_dim) / 2)
-	if t.orientation == .horizontal {
-		t_x := pos - f32(t.thumb_width) / 2
+	if s.orientation == .horizontal {
+		t_x := pos - f32(s.thumb_width) / 2
 		t_y := middle
-		return x >= t_x && x <= t_x + f32(t.thumb_width) && y >= t_y && y <= t_y + f32(t.thumb_height)
+		return x >= t_x && x <= t_x + f32(s.thumb_width) && y >= t_y && y <= t_y + f32(s.thumb_height)
 	}
 	else {
 		t_x := middle
-		t_y := pos - f32(t.thumb_height) / 2
-		return x >= t_x && x <= t_x + f32(t.thumb_width) && y >= t_y && y <= t_y + f32(t.thumb_height)
+		t_y := pos - f32(s.thumb_height) / 2
+		return x >= t_x && x <= t_x + f32(s.thumb_width) && y >= t_y && y <= t_y + f32(s.thumb_height)
 	}
 }

--- a/stack.v
+++ b/stack.v
@@ -35,32 +35,32 @@ mut:
 	margin 	MarginConfig
 }
 
-fn (mut b Stack) init(parent Layout) {
-	b.parent = parent
+fn (mut s Stack) init(parent Layout) {
+	s.parent = parent
 	ui := parent.get_ui()
 	w, h := parent.size()
-	b.ui = ui
+	s.ui = ui
 
-	if b.stretch {
-		b.height = h
-		b.width = w
+	if s.stretch {
+		s.height = h
+		s.width = w
 	} else {
-		if b.direction == .row {
-			b.width = w
+		if s.direction == .row {
+			s.width = w
 		} else {
-			b.height = h
+			s.height = h
 		}
 	}
-	b.height -= b.margin.top + b.margin.bottom
-	b.width -= b.margin.left + b.margin.right
-	b.set_pos(b.x, b.y)
-	for child in b.children {
-		child.init(b)
+	s.height -= s.margin.top + s.margin.bottom
+	s.width -= s.margin.left + s.margin.right
+	s.set_pos(s.x, s.y)
+	for child in s.children {
+		child.init(s)
 	}
 }
 
 fn stack(c StackConfig, children []Widget) &Stack {
-	mut b := &Stack{
+	mut s := &Stack{
 		height: c.height
 		width: c.width
 		vertical_alignment: c.vertical_alignment
@@ -72,107 +72,107 @@ fn stack(c StackConfig, children []Widget) &Stack {
 		children: children
 		ui: 0
 	}
-	return b
+	return s
 }
 
-fn (mut b Stack) set_pos(x, y int) {
-	b.x = x + b.margin.left
-	b.y = y + b.margin.top
+fn (mut s Stack) set_pos(x, y int) {
+	s.x = x + s.margin.left
+	s.y = y + s.margin.top
 }
 
-fn (b &Stack) get_subscriber() &eventbus.Subscriber {
-	parent := b.parent
+fn (s &Stack) get_subscriber() &eventbus.Subscriber {
+	parent := s.parent
 	return parent.get_subscriber()
 }
 
-fn (mut b Stack) propose_size(w, h int) (int,int) {
-	if b.stretch {
-		b.width = w
-		b.height = h
+fn (mut s Stack) propose_size(w, h int) (int,int) {
+	if s.stretch {
+		s.width = w
+		s.height = h
 	}
-	return b.width, b.height
+	return s.width, s.height
 }
 
 fn (c &Stack) size() (int, int) {
 	return c.width, c.height
 }
 
-fn (mut b Stack) draw() {
-	mut per_child_size := b.get_height()
-	mut pos := b.get_y_axis()
+fn (mut s Stack) draw() {
+	mut per_child_size := s.get_height()
+	mut pos := s.get_y_axis()
 	mut size := 0
-	for child in b.children {
+	for child in s.children {
 		mut h := 0
 		mut w := 0
-		if b.direction == .row {
-			h, w = child.propose_size(per_child_size, b.height)
-			child.set_pos(pos, b.align(w))
+		if s.direction == .row {
+			h, w = child.propose_size(per_child_size, s.height)
+			child.set_pos(pos, s.align(w))
 		} else {
-			w, h = child.propose_size(b.width, per_child_size)
-			child.set_pos(b.align(w), pos)
+			w, h = child.propose_size(s.width, per_child_size)
+			child.set_pos(s.align(w), pos)
 		}
 		if w > size {size = w}
 		child.draw()
-		pos += h + b.spacing
-		per_child_size -= h + b.spacing
+		pos += h + s.spacing
+		per_child_size -= h + s.spacing
 	}
-	if b.stretch {return}
-	b.set_height(pos - b.get_y_axis())
-	s := b.get_width()
-	if s == 0 || s < size {
-		b.set_width(size)
+	if s.stretch {return}
+	s.set_height(pos - s.get_y_axis())
+	w := s.get_width()
+	if w == 0 || w < size {
+		s.set_width(size)
 	}
 }
-fn (b &Stack) align(size int) int {
-	align := if b.direction == .row { int(b.vertical_alignment) } else { int(b.horizontal_alignment) }
+fn (s &Stack) align(size int) int {
+	align := if s.direction == .row { int(s.vertical_alignment) } else { int(s.horizontal_alignment) }
 	match align {
 		0 {
-			return b.get_x_axis()
+			return s.get_x_axis()
 		}
 		1 {
-			return b.get_x_axis() + ((b.get_width() - size) / 2)
+			return s.get_x_axis() + ((s.get_width() - size) / 2)
 		}
 		2 {
-			return (b.get_x_axis() + b.get_width()) - size
+			return (s.get_x_axis() + s.get_width()) - size
 		}
-		else {return b.get_x_axis()}
+		else {return s.get_x_axis()}
 	}
 }
 
-fn (t &Stack) get_ui() &UI {
-	return t.ui
+fn (s &Stack) get_ui() &UI {
+	return s.ui
 }
 
-fn (t &Stack) unfocus_all() {
-	for child in t.children {
+fn (s &Stack) unfocus_all() {
+	for child in s.children {
 		child.unfocus()
 	}
 }
 
-fn (t &Stack) get_state() voidptr {
-	parent := t.parent
+fn (s &Stack) get_state() voidptr {
+	parent := s.parent
 	return parent.get_state()
 }
 
-fn (t &Stack) point_inside(x, y f64) bool {
-	return false // x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (s &Stack) point_inside(x, y f64) bool {
+	return false // x >= s.x && x <= s.x + s.width && y >= s.y && y <= s.y + s.height
 }
 
-fn (mut b Stack) focus() {
-	// b.is_focused = true
+fn (mut s Stack) focus() {
+	// s.is_focused = true
 	//println('')
 }
 
-fn (mut b Stack) unfocus() {
-	// b.is_focused = false
+fn (mut s Stack) unfocus() {
+	// s.is_focused = false
 	//println('')
 }
 
-fn (t &Stack) is_focused() bool {
-	return false // t.is_focused
+fn (s &Stack) is_focused() bool {
+	return false // s.is_focused
 }
 
-fn (t &Stack) resize(width, height int) {
+fn (s &Stack) resize(width, height int) {
 }
 
 /* Helpers to correctly get height, width, x, y for both row & column
@@ -183,23 +183,23 @@ fn (t &Stack) resize(width, height int) {
    X -> Y
    Y -> X
  */
-fn (b &Stack) get_height() int {
-	return if b.direction == .row {b.width} else {b.height}
+fn (s &Stack) get_height() int {
+	return if s.direction == .row {s.width} else {s.height}
 }
-fn (b &Stack) get_width() int {
-	return if b.direction == .row {b.height} else {b.width}
+fn (s &Stack) get_width() int {
+	return if s.direction == .row {s.height} else {s.width}
 }
-fn (b &Stack) get_y_axis() int {
-	return if b.direction == .row {b.x} else {b.y}
+fn (s &Stack) get_y_axis() int {
+	return if s.direction == .row {s.x} else {s.y}
 }
-fn (b &Stack) get_x_axis() int {
-	return if b.direction == .row {b.y} else {b.x}
+fn (s &Stack) get_x_axis() int {
+	return if s.direction == .row {s.y} else {s.x}
 }
-fn (mut b Stack) set_height(h int) int {
-	if b.direction == .row {b.width = h} else {b.height = h}
+fn (mut s Stack) set_height(h int) int {
+	if s.direction == .row {s.width = h} else {s.height = h}
 	return h
 }
-fn (mut b Stack) set_width(w int) int {
-	if b.direction == .row {b.height = w} else {b.width = w}
+fn (mut s Stack) set_width(w int) int {
+	if s.direction == .row {s.height = w} else {s.width = w}
 	return w
 }

--- a/switch.v
+++ b/switch.v
@@ -43,62 +43,62 @@ fn (mut s Switch) init(parent Layout){
 }
 
 pub fn switcher(c SwitchConfig) &Switch {
-	mut sw := &Switch{
+	mut s := &Switch{
 		height: sw_height
 		width: sw_width
 		open:c.open
 		onclick: c.onclick
 		ui: 0
 	}
-	return sw
+	return s
 }
 
-fn (mut b Switch) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut s Switch) set_pos(x, y int) {
+	s.x = x
+	s.y = y
 }
 
-fn (mut b Switch) size() (int, int) {
-	return b.width, b.height
+fn (mut s Switch) size() (int, int) {
+	return s.width, s.height
 }
 
-fn (mut b Switch) propose_size(w, h int) (int, int) {
-	return b.width, b.height
+fn (mut s Switch) propose_size(w, h int) (int, int) {
+	return s.width, s.height
 }
 
-fn (mut b Switch) draw() {
-	padding := (b.height-sw_dot_size)/2
-	if b.open {
-	    b.ui.gg.draw_rect(b.x, b.y, b.width, b.height, sw_open_bg_color)
-		b.ui.gg.draw_rect(b.x - padding + b.width - sw_dot_size , b.y + padding, sw_dot_size, sw_dot_size, gx.white)
+fn (mut s Switch) draw() {
+	padding := (s.height-sw_dot_size)/2
+	if s.open {
+	    s.ui.gg.draw_rect(s.x, s.y, s.width, s.height, sw_open_bg_color)
+		s.ui.gg.draw_rect(s.x - padding + s.width - sw_dot_size , s.y + padding, sw_dot_size, sw_dot_size, gx.white)
 	}else{
-	    b.ui.gg.draw_rect(b.x, b.y, b.width, b.height, sw_close_bg_color)
-	    b.ui.gg.draw_rect(b.x + padding, b.y + padding, sw_dot_size, sw_dot_size, gx.white)
+	    s.ui.gg.draw_rect(s.x, s.y, s.width, s.height, sw_close_bg_color)
+	    s.ui.gg.draw_rect(s.x + padding, s.y + padding, sw_dot_size, sw_dot_size, gx.white)
 	}
 }
 
-fn (t &Switch) point_inside(x, y f64) bool {
-	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (s &Switch) point_inside(x, y f64) bool {
+	return x >= s.x && x <= s.x + s.width && y >= s.y && y <= s.y + s.height
 }
 
-fn sw_click(mut b Switch, e &MouseEvent, w &Window) {
-	if !b.point_inside(e.x, e.y) { return }	//<===== mouse position test added
+fn sw_click(mut s Switch, e &MouseEvent, w &Window) {
+	if !s.point_inside(e.x, e.y) { return }	//<===== mouse position test added
 	if e.action == 0 {
-		b.open = !b.open
-		if b.onclick != voidptr(0) {
-			b.onclick(w.state, b)
+		s.open = !s.open
+		if s.onclick != voidptr(0) {
+			s.onclick(w.state, s)
 		}
 	}
 }
 
-fn (mut b Switch) focus() {
-	b.is_focused = true
+fn (mut s Switch) focus() {
+	s.is_focused = true
 }
 
-fn (mut b Switch) unfocus() {
-	b.is_focused = false
+fn (mut s Switch) unfocus() {
+	s.is_focused = false
 }
 
-fn (t &Switch) is_focused() bool {
-	return t.is_focused
+fn (s &Switch) is_focused() bool {
+	return s.is_focused
 }

--- a/textbox.v
+++ b/textbox.v
@@ -148,12 +148,12 @@ pub fn textbox(c TextBoxConfig) &TextBox {
 	return tb
 }
 
-//fn (t &TextBox) draw_inner_border() {
+//fn (tb &TextBox) draw_inner_border() {
 fn draw_inner_border(border_accentuated bool, gg &gg.Context, x, y, width, height int, is_error bool) {
 	if !border_accentuated {
 		color := if is_error { gx.rgb(255,0,0) } else { text_border_color }
 		gg.draw_empty_rect(x, y, width, height, color)
-		//gg.draw_empty_rect(t.x, t.y, t.width, t.height, color) //text_border_color)
+		//gg.draw_empty_rect(tb.x, tb.y, tb.width, tb.height, color) //text_border_color)
 		// TODO this should be +-1, not 0.5, a bug in gg/opengl
 		gg.draw_empty_rect(0.5 + f32(x), 0.5 + f32(y), width - 1, height - 1, text_inner_border_color) // inner lighter border
 	}
@@ -163,134 +163,134 @@ fn draw_inner_border(border_accentuated bool, gg &gg.Context, x, y, width, heigh
 	}
 }
 
-fn (mut b TextBox) set_pos(x, y int) {
-	b.x = x
-	b.y = y
+fn (mut tb TextBox) set_pos(x, y int) {
+	tb.x = x
+	tb.y = y
 }
 
-fn (mut b TextBox) size() (int,int) {
-	return b.width,b.height
+fn (mut tb TextBox) size() (int,int) {
+	return tb.width,tb.height
 }
 
-fn (mut b TextBox) propose_size(w, h int) (int,int) {
-	return b.width,b.height
+fn (mut tb TextBox) propose_size(w, h int) (int,int) {
+	return tb.width,tb.height
 }
 
-fn (mut t TextBox) draw() {
-	text:=*(t.text)
-	mut placeholder := t.placeholder
-	if t.placeholder_bind != 0 {
-	placeholder=*(t.placeholder_bind)
+fn (mut tb TextBox) draw() {
+	text:=*(tb.text)
+	mut placeholder := tb.placeholder
+	if tb.placeholder_bind != 0 {
+	placeholder=*(tb.placeholder_bind)
 	}
-	t.ui.gg.draw_rect(t.x, t.y, t.width, t.height, gx.white)
-	if !t.borderless {
-		draw_inner_border(t.border_accentuated, t.ui.gg, t.x, t.y, t.width, t.height, t.is_error != 0 && *t.is_error)
+	tb.ui.gg.draw_rect(tb.x, tb.y, tb.width, tb.height, gx.white)
+	if !tb.borderless {
+		draw_inner_border(tb.border_accentuated, tb.ui.gg, tb.x, tb.y, tb.width, tb.height, tb.is_error != 0 && *tb.is_error)
 	}
-	width := if text.len == 0 { 0 } else { t.ui.gg.text_width(text) }
-	text_y := t.y + 2 // TODO off by 1px
+	width := if text.len == 0 { 0 } else { tb.ui.gg.text_width(text) }
+	text_y := tb.y + 2 // TODO off by 1px
 	mut skip_idx := 0
 	// Placeholder
 	if text == '' && placeholder != '' {
-		t.ui.gg.draw_text(t.x + textbox_padding, text_y, placeholder, placeholder_cfg)
+		tb.ui.gg.draw_text(tb.x + textbox_padding, text_y, placeholder, placeholder_cfg)
 	}
 	// Text
 	else {
 		// Selection box
-		// if t.sel_start != 0 {
+		// if tb.sel_start != 0 {
 		ustr := text.ustring()
-		if t.sel_start < t.sel_end && t.sel_start < ustr.len {
-			left := ustr.left(t.sel_start)
-			right := ustr.right(t.sel_end)
-			sel_width := width - t.ui.gg.text_width(right) - t.ui.gg.text_width(left)
-			x := t.ui.gg.text_width(left) + t.x + textbox_padding
-			t.ui.gg.draw_rect(x, t.y + 3, sel_width, t.height - 6, selection_color)
+		if tb.sel_start < tb.sel_end && tb.sel_start < ustr.len {
+			left := ustr.left(tb.sel_start)
+			right := ustr.right(tb.sel_end)
+			sel_width := width - tb.ui.gg.text_width(right) - tb.ui.gg.text_width(left)
+			x := tb.ui.gg.text_width(left) + tb.x + textbox_padding
+			tb.ui.gg.draw_rect(x, tb.y + 3, sel_width, tb.height - 6, selection_color)
 			/*
-			sel_width := t.ui.gg.text_width(right) + 1
+			sel_width := tb.ui.gg.text_width(right) + 1
 			 */
 
 		}
-		// The text doesn't fit, find the largest substring we can draw
-		if width > t.width {
+		// The text doesn'tb fit, find the largest substring we can draw
+		if width > tb.width {
 			for i := text.len - 1; i >= 0; i-- {
 				if i >= text.len {
 					continue
 				}
-				if t.ui.gg.text_width(text[i..]) > t.width {
+				if tb.ui.gg.text_width(text[i..]) > tb.width {
 					skip_idx = i + 3
 					break
 				}
 			}
-			t.ui.gg.draw_text_def(t.x + textbox_padding, text_y, text[skip_idx..])
+			tb.ui.gg.draw_text_def(tb.x + textbox_padding, text_y, text[skip_idx..])
 		}
 		else {
-			if t.is_password {
+			if tb.is_password {
 				/*
-				for i in 0..t.text.len {
+				for i in 0..tb.text.len {
 					// TODO drawing multiple circles is broken
-					//t.ui.gg.draw_image(t.x + 5 + i * 12, t.y + 5, 8, 8, t.ui.circle_image)
+					//tb.ui.gg.draw_image(tb.x + 5 + i * 12, tb.y + 5, 8, 8, tb.ui.circle_image)
 				}
 				*/
-				t.ui.gg.draw_text_def(t.x + textbox_padding, text_y, strings.repeat(`*`, text.len))
+				tb.ui.gg.draw_text_def(tb.x + textbox_padding, text_y, strings.repeat(`*`, text.len))
 			}
 			else {
-				t.ui.gg.draw_text_def(t.x + textbox_padding, text_y, text)
+				tb.ui.gg.draw_text_def(tb.x + textbox_padding, text_y, text)
 			}
 		}
 	}
 	// Draw the cursor
-	if t.is_focused && !t.read_only && t.ui.show_cursor && t.sel_start == 0 &&
-		t.sel_end == 0 {
+	if tb.is_focused && !tb.read_only && tb.ui.show_cursor && tb.sel_start == 0 &&
+		tb.sel_end == 0 {
 		// no cursor in sel mode
-		mut cursor_x := t.x + textbox_padding
-		if t.is_password {
-			cursor_x += t.ui.gg.text_width(strings.repeat(`*`, t.cursor_pos))
+		mut cursor_x := tb.x + textbox_padding
+		if tb.is_password {
+			cursor_x += tb.ui.gg.text_width(strings.repeat(`*`, tb.cursor_pos))
 		}
 		else if skip_idx > 0 {
-			cursor_x += t.ui.gg.text_width(text[skip_idx..])
+			cursor_x += tb.ui.gg.text_width(text[skip_idx..])
 		}
 		else if text.len > 0 {
-			// left := t.text[..t.cursor_pos]
-			left := text.ustring().left(t.cursor_pos)
-			cursor_x += t.ui.gg.text_width(left)
+			// left := tb.text[..tb.cursor_pos]
+			left := text.ustring().left(tb.cursor_pos)
+			cursor_x += tb.ui.gg.text_width(left)
 		}
 		if text.len == 0 {
-			cursor_x = t.x + textbox_padding
+			cursor_x = tb.x + textbox_padding
 		}
-		// t.ui.gg.draw_line(cursor_x, t.y+2, cursor_x, t.y-2+t.height-1)//, gx.Black)
-		t.ui.gg.draw_rect(cursor_x, t.y + 3, 1, t.height - 6, gx.black) // , gx.Black)
+		// tb.ui.gg.draw_line(cursor_x, tb.y+2, cursor_x, tb.y-2+tb.height-1)//, gx.Black)
+		tb.ui.gg.draw_rect(cursor_x, tb.y + 3, 1, tb.height - 6, gx.black) // , gx.Black)
 	}
 }
 
-fn tb_key_up(mut t TextBox, e &KeyEvent, window &Window) {
-	if !t.is_focused {
+fn tb_key_up(mut tb TextBox, e &KeyEvent, window &Window) {
+	if !tb.is_focused {
 		return
 	}
-	if t.on_key_up != voidptr(0) {
-		t.on_key_up(window.state, t, e.codepoint)
+	if tb.on_key_up != voidptr(0) {
+		tb.on_key_up(window.state, tb, e.codepoint)
 	}
 }
 
-fn tb_key_down(mut t TextBox, e &KeyEvent, window &Window) {
-	text := *t.text
-	if !t.is_focused {
+fn tb_key_down(mut tb TextBox, e &KeyEvent, window &Window) {
+	text := *tb.text
+	if !tb.is_focused {
 		//println('textbox.key_down on an unfocused textbox, this should never happen')
 		return
 	}
-	if t.is_error != voidptr(0) {
+	if tb.is_error != voidptr(0) {
 		unsafe {
-			*t.is_error = false
+			*tb.is_error = false
 		}
 	}
-	t.is_typing = true
-	if t.on_key_down != voidptr(0) {
-		t.on_key_down(window.state, t, e.codepoint)
+	tb.is_typing = true
+	if tb.on_key_down != voidptr(0) {
+		tb.on_key_down(window.state, tb, e.codepoint)
 	}
-	t.ui.last_type_time = time.ticks() // TODO perf?
+	tb.ui.last_type_time = time.ticks() // TODO perf?
 	if e.codepoint != 0 {
-		if t.read_only {
+		if tb.read_only {
 			return
 		}
-		if t.max_len > 0 && text.len >= t.max_len {
+		if tb.max_len > 0 && text.len >= tb.max_len {
 			return
 		}
 		if byte(e.codepoint) in [`\t`, 127] {
@@ -298,137 +298,137 @@ fn tb_key_down(mut t TextBox, e &KeyEvent, window &Window) {
 			return
 		}
 		s := utf32_to_str(e.codepoint)
-		// if (t.is_numeric && (s.len > 1 || !s[0].is_digit()  ) {
-		if t.is_numeric && (s.len > 1 || (!s[0].is_digit() && ((s[0] != `-`) || ((text.len > 0) && (t.cursor_pos > 0))))) {
+		// if (tb.is_numeric && (s.len > 1 || !s[0].is_digit()  ) {
+		if tb.is_numeric && (s.len > 1 || (!s[0].is_digit() && ((s[0] != `-`) || ((text.len > 0) && (tb.cursor_pos > 0))))) {
 			return
 		}
-		t.insert(s)
-		if t.on_change != TextBoxChangeFn(0) {
-			t.on_change(*t.text, window.state)
+		tb.insert(s)
+		if tb.on_change != TextBoxChangeFn(0) {
+			tb.on_change(*tb.text, window.state)
 		}
-		//println('T "$s " $t.cursor_pos')
-		// t.text += s
-		// t.cursor_pos ++//= utf8_char_len(s[0])// s.le-112
+		//println('T "$s " $tb.cursor_pos')
+		// tb.text += s
+		// tb.cursor_pos ++//= utf8_char_len(s[0])// s.le-112
 		return
 	}
 	// println(e.key)
 	// println('mods=$e.mods')
 	match e.key {
 		.backspace {
-			t.ui.show_cursor = true
+			tb.ui.show_cursor = true
 			if text != '' {
-				if t.cursor_pos == 0 {
+				if tb.cursor_pos == 0 {
 					return
 				}
 				u := text.ustring()
 				// Delete the entire selection
-				if t.sel_start < t.sel_end {
+				if tb.sel_start < tb.sel_end {
 					unsafe {
-						*t.text = u.left(t.sel_start) + u.right(t.sel_end)
+						*tb.text = u.left(tb.sel_start) + u.right(tb.sel_end)
 					}
-					t.cursor_pos = t.sel_start
-					t.sel_start = 0
-					t.sel_end = 0
+					tb.cursor_pos = tb.sel_start
+					tb.sel_start = 0
+					tb.sel_end = 0
 				}
 				else if e.mods in [.super, .ctrl] {
 					// Delete until previous whitespace
-					mut i := t.cursor_pos
+					mut i := tb.cursor_pos
 					for {
 						if i > 0 {
 							i--
 						}
 						if text[i].is_space() || i == 0 {
 							unsafe {
-							//*t.text = u.left(i) + u.right(t.cursor_pos)
+							//*tb.text = u.left(i) + u.right(tb.cursor_pos)
 							}
 							break
 						}
 					}
-					t.cursor_pos = i
+					tb.cursor_pos = i
 				}
 				else {
 					// Delete just one character
 					unsafe {
-					*t.text = u.left(t.cursor_pos - 1) + u.right(t.cursor_pos)
+					*tb.text = u.left(tb.cursor_pos - 1) + u.right(tb.cursor_pos)
 					}
-					t.cursor_pos--
+					tb.cursor_pos--
 				}
 				// u.free() // TODO remove
-				// t.text = t.text[..t.cursor_pos - 1] + t.text[t.cursor_pos..]
+				// tb.text = tb.text[..tb.cursor_pos - 1] + tb.text[tb.cursor_pos..]
 			}
-			if t.on_change != TextBoxChangeFn(0) {
-				//t.on_change(*t.text, window.state)
+			if tb.on_change != TextBoxChangeFn(0) {
+				//tb.on_change(*tb.text, window.state)
 			}
 		}
 		.delete {
-			t.ui.show_cursor = true
-			if t.cursor_pos == text.len || text == '' {
+			tb.ui.show_cursor = true
+			if tb.cursor_pos == text.len || text == '' {
 				return
 			}
 			u := text.ustring()
 			unsafe {
-			*t.text = u.left(t.cursor_pos) + u.right(t.cursor_pos + 1)
+			*tb.text = u.left(tb.cursor_pos) + u.right(tb.cursor_pos + 1)
 			}
-			// t.text = t.text[..t.cursor_pos] + t.text[t.cursor_pos + 1..]
+			// tb.text = tb.text[..tb.cursor_pos] + tb.text[tb.cursor_pos + 1..]
 			// u.free() // TODO remove
-			if t.on_change != TextBoxChangeFn(0) {
-				//t.on_change(*t.text, window.state)
+			if tb.on_change != TextBoxChangeFn(0) {
+				//tb.on_change(*tb.text, window.state)
 			}
 		}
 		.left {
-			if t.sel(e.mods, e.key) {
+			if tb.sel(e.mods, e.key) {
 				return
 			}
-			if t.sel_end > 0 {
-				t.cursor_pos = t.sel_start + 1
+			if tb.sel_end > 0 {
+				tb.cursor_pos = tb.sel_start + 1
 			}
-			t.sel_start = 0
-			t.sel_end = 0
-			t.ui.show_cursor = true // always show cursor when moving it (left, right, backspace etc)
-			t.cursor_pos--
-			if t.cursor_pos <= 0 {
-				t.cursor_pos = 0
+			tb.sel_start = 0
+			tb.sel_end = 0
+			tb.ui.show_cursor = true // always show cursor when moving it (left, right, backspace etc)
+			tb.cursor_pos--
+			if tb.cursor_pos <= 0 {
+				tb.cursor_pos = 0
 			}
 		}
 		.right {
-			if t.sel(e.mods, e.key) {
+			if tb.sel(e.mods, e.key) {
 				return
 			}
-			if t.sel_start > 0 {
-				t.cursor_pos = t.sel_end - 1
+			if tb.sel_start > 0 {
+				tb.cursor_pos = tb.sel_end - 1
 			}
-			t.sel_end = 0
-			t.sel_start = 0
-			t.ui.show_cursor = true
-			t.cursor_pos++
-			if t.cursor_pos > text.len {
-				t.cursor_pos = text.len
+			tb.sel_end = 0
+			tb.sel_start = 0
+			tb.ui.show_cursor = true
+			tb.cursor_pos++
+			if tb.cursor_pos > text.len {
+				tb.cursor_pos = text.len
 			}
 		}
 		.a {
 			if e.mods in [.super, .ctrl] {
-				t.sel_start = 0
-				t.sel_end = text.ustring().len - 1
+				tb.sel_start = 0
+				tb.sel_end = text.ustring().len - 1
 			}
 		}
 		.v {
 			if e.mods in [.super, .ctrl] {
-				t.insert(t.ui.clipboard.paste())
+				tb.insert(tb.ui.clipboard.paste())
 			}
 		}
 		.tab {
-			t.ui.show_cursor = true
-			/*TODO if t.parent.just_tabbed {
-				t.parent.just_tabbed = false
+			tb.ui.show_cursor = true
+			/*TODO if tb.parent.just_tabbed {
+				tb.parent.just_tabbed = false
 				return
 			} */
 
-			//println('TAB $t.id')
+			//println('TAB $tb.id')
 			/* if e.mods == .shift {
-				t.parent.focus_previous()
+				tb.parent.focus_previous()
 			}
 			else {
-				t.parent.focus_next()
+				tb.parent.focus_next()
 			} */
 
 		}
@@ -436,23 +436,23 @@ fn tb_key_down(mut t TextBox, e &KeyEvent, window &Window) {
 	}
 }
 
-fn (mut t TextBox) set_sel(sel_start, sel_end int, key Key) {
-	if t.sel_direction == .right_to_left {
-		t.sel_start = sel_start
-		t.sel_end = sel_end
+fn (mut tb TextBox) set_sel(sel_start, sel_end int, key Key) {
+	if tb.sel_direction == .right_to_left {
+		tb.sel_start = sel_start
+		tb.sel_end = sel_end
 	}
 	else {
-		t.sel_start = sel_end
-		t.sel_end = sel_start
+		tb.sel_start = sel_end
+		tb.sel_end = sel_start
 	}
 }
 
-fn (mut t TextBox) sel(mods KeyMod, key Key) bool {
-	mut sel_start := if t.sel_direction == .right_to_left { t.sel_start } else { t.sel_end }
-	mut sel_end := if t.sel_direction == .right_to_left { t.sel_end } else { t.sel_start }
-	text := *t.text
+fn (mut tb TextBox) sel(mods KeyMod, key Key) bool {
+	mut sel_start := if tb.sel_direction == .right_to_left { tb.sel_start } else { tb.sel_end }
+	mut sel_end := if tb.sel_direction == .right_to_left { tb.sel_end } else { tb.sel_start }
+	text := *tb.text
 	if mods == int(KeyMod.shift) + int(KeyMod.ctrl) {
-		mut i := t.cursor_pos
+		mut i := tb.cursor_pos
 		if sel_start > 0 {
 			i = if key == .left { sel_start - 1 } else { sel_start + 1 }
 		}
@@ -460,14 +460,14 @@ fn (mut t TextBox) sel(mods KeyMod, key Key) bool {
 			i = 0
 		}
 		else {
-			t.sel_direction = if key == .left { SelectionDirection.right_to_left } else { SelectionDirection.left_to_right }
+			tb.sel_direction = if key == .left { SelectionDirection.right_to_left } else { SelectionDirection.left_to_right }
 		}
-		sel_end = t.cursor_pos
+		sel_end = tb.cursor_pos
 		for {
 			if key == .left && i > 0 {
 				i--
 			}
-			else if key == .right && i < t.text.len {
+			else if key == .right && i < tb.text.len {
 				i++
 			}
 			if i == 0 {
@@ -475,178 +475,178 @@ fn (mut t TextBox) sel(mods KeyMod, key Key) bool {
 				break
 			}
 			else if i == text.len {
-				sel_start = t.text.len
+				sel_start = tb.text.len
 				break
 			}
 			else if text[i].is_space() {
-				sel_start = if t.sel_direction == .right_to_left { i + 1 } else { i }
+				sel_start = if tb.sel_direction == .right_to_left { i + 1 } else { i }
 				break
 			}
 		}
-		t.set_sel(sel_start, sel_end, key)
+		tb.set_sel(sel_start, sel_end, key)
 		return true
 	}
 	if mods == .shift {
-		if (t.sel_direction == .right_to_left && sel_start == 0 && sel_end > 0) || (t.sel_direction == .left_to_right && sel_end == t.text.len) {
+		if (tb.sel_direction == .right_to_left && sel_start == 0 && sel_end > 0) || (tb.sel_direction == .left_to_right && sel_end == tb.text.len) {
 			return true
 		}
 		if sel_start <= 0 {
-			sel_end = t.cursor_pos
-			sel_start = if key == .left { t.cursor_pos - 1 } else { t.cursor_pos + 1 }
-			t.sel_direction = if key == .left { SelectionDirection.right_to_left } else { SelectionDirection.left_to_right }
+			sel_end = tb.cursor_pos
+			sel_start = if key == .left { tb.cursor_pos - 1 } else { tb.cursor_pos + 1 }
+			tb.sel_direction = if key == .left { SelectionDirection.right_to_left } else { SelectionDirection.left_to_right }
 		}
 		else {
 			sel_start = if key == .left { sel_start - 1 } else { sel_start + 1 }
 		}
-		t.set_sel(sel_start, sel_end, key)
+		tb.set_sel(sel_start, sel_end, key)
 		return true
 	}
 	return false
 }
 
-fn (t &TextBox) point_inside(x, y f64) bool {
-	return x >= t.x && x <= t.x + t.width && y >= t.y && y <= t.y + t.height
+fn (tb &TextBox) point_inside(x, y f64) bool {
+	return x >= tb.x && x <= tb.x + tb.width && y >= tb.y && y <= tb.y + tb.height
 }
 
-fn tb_mouse_move(mut t TextBox, e &MouseEvent, zzz voidptr) {
-	if !t.point_inside(e.x, e.y) {
+fn tb_mouse_move(mut tb TextBox, e &MouseEvent, zzz voidptr) {
+	if !tb.point_inside(e.x, e.y) {
 		return
 	}
-	if t.dragging {
-		x := e.x - t.x - textbox_padding
-		reverse := x - t.last_x < 0
-		if t.sel_start <= 0 {
-			t.sel_start = t.cursor_pos
+	if tb.dragging {
+		x := e.x - tb.x - textbox_padding
+		reverse := x - tb.last_x < 0
+		if tb.sel_start <= 0 {
+			tb.sel_start = tb.cursor_pos
 		}
-		t.last_x = x
+		tb.last_x = x
 		mut prev_width := 0
-		ustr := t.text.ustring()
+		ustr := tb.text.ustring()
 		for i in 1 .. ustr.len {
-			width := t.ui.gg.text_width(ustr.left(i))
+			width := tb.ui.gg.text_width(ustr.left(i))
 			if prev_width <= x && x <= width {
-				if i < t.sel_start && t.sel_end < t.sel_start {
-					t.sel_end = t.sel_start
-					t.sel_start = i
+				if i < tb.sel_start && tb.sel_end < tb.sel_start {
+					tb.sel_end = tb.sel_start
+					tb.sel_start = i
 					return
 				}
 				if reverse {
-					t.sel_start = i
+					tb.sel_start = i
 				}
 				else {
-					t.sel_end = i
+					tb.sel_end = i
 				}
 				return
 			}
 			prev_width = width
 		}
 		if reverse {
-			t.sel_start = 0
+			tb.sel_start = 0
 		}
 		else {
-			t.sel_end = t.text.len
+			tb.sel_end = tb.text.len
 		}
 	}
 }
 
-fn tb_click(mut t TextBox, e &MouseEvent, zzz voidptr) {
-	if !t.point_inside(e.x, e.y) {
-		t.dragging = false
+fn tb_click(mut tb TextBox, e &MouseEvent, zzz voidptr) {
+	if !tb.point_inside(e.x, e.y) {
+		tb.dragging = false
 		return
 	}
-	if !t.dragging && e.action == 1 {
-		t.sel_start = 0
-		t.sel_end = 0
+	if !tb.dragging && e.action == 1 {
+		tb.sel_start = 0
+		tb.sel_end = 0
 	}
-	t.dragging = e.action == 1
-	t.ui.show_cursor = true
-	t.focus()
-	if *t.text == '' {
+	tb.dragging = e.action == 1
+	tb.ui.show_cursor = true
+	tb.focus()
+	if *tb.text == '' {
 		return
 	}
 	// Calculate cursor position from x
-	x := e.x - t.x - textbox_padding
+	x := e.x - tb.x - textbox_padding
 	if x <= 0 {
-		t.cursor_pos = 0
+		tb.cursor_pos = 0
 		return
 	}
 	mut prev_width := 0
-	ustr := t.text.ustring()
+	ustr := tb.text.ustring()
 	for i in 1 .. ustr.len {
-		// width := t.ui.gg.text_width(t.text[..i])
-		width := t.ui.gg.text_width(ustr.left(i))
+		// width := tb.ui.gg.text_width(tb.text[..i])
+		width := tb.ui.gg.text_width(ustr.left(i))
 		if prev_width <= x && x <= width {
-			t.cursor_pos = i
+			tb.cursor_pos = i
 			return
 		}
 		prev_width = width
 	}
-	t.cursor_pos = t.text.len
+	tb.cursor_pos = tb.text.len
 }
 
-pub fn (mut t TextBox) focus() {
-	if t.is_focused {
+pub fn (mut tb TextBox) focus() {
+	if tb.is_focused {
 		return
 	}
-	parent := t.parent
+	parent := tb.parent
 	parent.unfocus_all()
-	t.is_focused = true
+	tb.is_focused = true
 }
 
-fn (t &TextBox) is_focused() bool {
-	return t.is_focused
+fn (tb &TextBox) is_focused() bool {
+	return tb.is_focused
 }
 
-fn (mut t TextBox) unfocus() {
-	t.is_focused = false
-	t.sel_start = 0
-	t.sel_end = 0
+fn (mut tb TextBox) unfocus() {
+	tb.is_focused = false
+	tb.sel_start = 0
+	tb.sel_end = 0
 }
 
-fn (mut t TextBox) update() {
-	t.cursor_pos = t.text.ustring().len
+fn (mut tb TextBox) update() {
+	tb.cursor_pos = tb.text.ustring().len
 }
 
-pub fn (mut t TextBox) hide() {}
+pub fn (mut tb TextBox) hide() {}
 
-pub fn (mut t TextBox) set_text(s string) {
-	//t.text = s
-	//t.update()
+pub fn (mut tb TextBox) set_text(s string) {
+	//tb.text = s
+	//tb.update()
 }
 
-//pub fn (mut t TextBox) on_change(func voidptr) {
+//pub fn (mut tb TextBox) on_change(func voidptr) {
 //}
 
-pub fn (mut t TextBox) on_return(func voidptr) {
+pub fn (mut tb TextBox) on_return(func voidptr) {
 }
 
-pub fn (mut t TextBox) insert(s string) {
-	mut ustr := t.text.ustring()
+pub fn (mut tb TextBox) insert(s string) {
+	mut ustr := tb.text.ustring()
 	old_len := ustr.len
 	// Remove the selection
-	if t.sel_start < t.sel_end {
+	if tb.sel_start < tb.sel_end {
 		unsafe {
-		*t.text = ustr.left(t.sel_start) + s + ustr.right(t.sel_end + 1)
+		*tb.text = ustr.left(tb.sel_start) + s + ustr.right(tb.sel_end + 1)
 		}
 	}
 	else {
 		// Insert one character
-		// t.text = t.text[..t.cursor_pos] + s + t.text[t.cursor_pos..]
+		// tb.text = tb.text[..tb.cursor_pos] + s + tb.text[tb.cursor_pos..]
 		unsafe {
-		*t.text = ustr.left(t.cursor_pos) + s + ustr.right(t.cursor_pos)
+		*tb.text = ustr.left(tb.cursor_pos) + s + ustr.right(tb.cursor_pos)
 		}
 
-		ustr = t.text.ustring()
+		ustr = tb.text.ustring()
 		// The string is too long
-		if t.max_len > 0 && ustr.len >= t.max_len {
-			// t.text = t.text.limit(t.max_len)
+		if tb.max_len > 0 && ustr.len >= tb.max_len {
+			// tb.text = tb.text.limit(tb.max_len)
 			unsafe {
-			*t.text = ustr.left(t.max_len)
+			*tb.text = ustr.left(tb.max_len)
 			}
-			ustr = t.text.ustring()
+			ustr = tb.text.ustring()
 		}
 	}
-	// t.cursor_pos += t.text.len - old_len
-	t.cursor_pos += ustr.len - old_len
-	t.sel_start = 0
-	t.sel_end = 0
+	// tb.cursor_pos += tb.text.len - old_len
+	tb.cursor_pos += ustr.len - old_len
+	tb.sel_start = 0
+	tb.sel_end = 0
 }

--- a/transition.v
+++ b/transition.v
@@ -59,7 +59,7 @@ fn (t &Transition) propose_size(w, h int) (int, int) {
 	return 0,0
 }
 
-fn (mut b Transition) size() (int, int) {
+fn (mut t Transition) size() (int, int) {
 	return 0,0
 }
 

--- a/window.v
+++ b/window.v
@@ -509,7 +509,7 @@ pub fn (w &Window) mouse_inside(x, y, width, height int) bool {
 	return false
 }
 
-pub fn (b &Window) focus() {}
+pub fn (w &Window) focus() {}
 
 pub fn (w &Window) always_on_top(val bool) {
 	//w.glfw_obj.window_hint(


### PR DESCRIPTION
Due to a lots of copy paste the argument names in many functions were different and not even related to the widget name.
Now the arguments are in most cases the first letter of the widget name.

_I thoroughly checked that no new issues show up._