### PR TITLE
fix ui compilation with V 0.1.29 b44620d

### DIFF
--- a/window.v
+++ b/window.v
@@ -13,14 +13,14 @@ const (
 	default_font_size = 13
 )
 
-pub type DrawFn fn(ctx &gg.Context, state voidptr)
+pub type DrawFn = fn(ctx &gg.Context, state voidptr)
 
-pub type ClickFn fn(e MouseEvent, func voidptr)
-pub type KeyFn fn(e KeyEvent, func voidptr)
+pub type ClickFn = fn(e MouseEvent, func voidptr)
+pub type KeyFn = fn(e KeyEvent, func voidptr)
 
-pub type ScrollFn fn(e ScrollEvent, func voidptr)
+pub type ScrollFn = fn(e ScrollEvent, func voidptr)
 
-pub type MouseMoveFn fn(e MouseMoveEvent, func voidptr)
+pub type MouseMoveFn = fn(e MouseMoveEvent, func voidptr)
 
 [ref_only]
 pub struct Window {


### PR DESCRIPTION
Needed so that `./v run ~/.vmodules/ui/examples/users.v` works.