### PR TITLE
ui: add enum MouseButton for MouseEvent

### DIFF
--- a/ui.v
+++ b/ui.v
@@ -93,11 +93,19 @@ pub enum MouseAction {
 	down
 }
 
+// MouseButton is same to sapp.MouseButton
+pub enum MouseButton {
+    invalid = -1
+    left = 0
+    right = 1
+    middle = 2
+}
+
 pub struct MouseEvent {
 pub:
 	x      int
 	y      int
-	button int
+	button MouseButton
 	action MouseAction
 	mods   int
 }

--- a/window.v
+++ b/window.v
@@ -307,7 +307,7 @@ fn window_mouse_down(event sapp.Event, ui &UI) {
 		action: .down
 		x: int(event.mouse_x / ui.gg.scale)
 		y: int(event.mouse_y / ui.gg.scale)
-		button: event.mouse_button
+		button: MouseButton(event.mouse_button)
 	}
 	if window.mouse_down_fn != voidptr(0) { // && action == voidptr(0) {
 		window.mouse_down_fn(e, window)
@@ -334,7 +334,7 @@ fn window_mouse_up(event sapp.Event, ui &UI) {
 		action: .up
 		x: int(event.mouse_x / ui.gg.scale)
 		y: int(event.mouse_y / ui.gg.scale)
-		button: event.mouse_button
+		button: MouseButton(event.mouse_button)
 	}
 	if window.mouse_up_fn != voidptr(0) { // && action == voidptr(0) {
 		window.mouse_up_fn(e, window)
@@ -361,7 +361,7 @@ fn window_click(event sapp.Event, ui &UI) {
 		action: if event.typ == .mouse_up { MouseAction.up } else { MouseAction.down }
 		x: int(event.mouse_x / ui.gg.scale)
 		y: int(event.mouse_y / ui.gg.scale)
-		button: event.mouse_button
+		button: MouseButton(event.mouse_button)
 	}
 	if window.click_fn != voidptr(0) { // && action == voidptr(0) {
 		window.click_fn(e, window)


### PR DESCRIPTION
1) Since MouseEvent.button is integer, changed to enum MouseButton.
2) for importing just ui module, copied from sapp.MouseButton to ui.MouseButton.