### PR TITLE
ui: change MoueEvent.mods from int to enum KeyMod

### DIFF
--- a/ui.v
+++ b/ui.v
@@ -107,7 +107,7 @@ pub:
 	y      int
 	button MouseButton
 	action MouseAction
-	mods   int
+	mods   KeyMod
 }
 
 pub struct ScrollEvent {

--- a/window.v
+++ b/window.v
@@ -308,6 +308,7 @@ fn window_mouse_down(event sapp.Event, ui &UI) {
 		x: int(event.mouse_x / ui.gg.scale)
 		y: int(event.mouse_y / ui.gg.scale)
 		button: MouseButton(event.mouse_button)
+		mods: KeyMod(event.modifiers)
 	}
 	if window.mouse_down_fn != voidptr(0) { // && action == voidptr(0) {
 		window.mouse_down_fn(e, window)
@@ -335,6 +336,7 @@ fn window_mouse_up(event sapp.Event, ui &UI) {
 		x: int(event.mouse_x / ui.gg.scale)
 		y: int(event.mouse_y / ui.gg.scale)
 		button: MouseButton(event.mouse_button)
+		mods: KeyMod(event.modifiers)
 	}
 	if window.mouse_up_fn != voidptr(0) { // && action == voidptr(0) {
 		window.mouse_up_fn(e, window)
@@ -362,6 +364,7 @@ fn window_click(event sapp.Event, ui &UI) {
 		x: int(event.mouse_x / ui.gg.scale)
 		y: int(event.mouse_y / ui.gg.scale)
 		button: MouseButton(event.mouse_button)
+		mods: KeyMod(event.modifiers)
 	}
 	if window.click_fn != voidptr(0) { // && action == voidptr(0) {
 		window.click_fn(e, window)


### PR DESCRIPTION
1) changed type of `ui.MouseEvent.mods` from `int` to `ui.KeyMod` which is also used in `ui.window_key_down()` method.
2) set `ui.MouseEvetn.mods` value `ui.window_mouse_down()` etc returns.