### PR TITLE
window: add on_window_resized event

### DIFF
--- a/const.v
+++ b/const.v
@@ -2,13 +2,14 @@ module ui
 
 struct EventNames {
 pub:
-	on_click      string = 'on_click'
-	on_mouse_move string = 'on_mouse_move'
-	on_mouse_down string = 'on_mouse_down'
-	on_mouse_up   string = 'on_mouse_up'
-	on_key_down   string = 'on_key_down'
-	on_key_up     string = 'on_key_up'
-	on_scroll     string = 'on_scroll'
+	on_click          string = 'on_click'
+	on_mouse_move     string = 'on_mouse_move'
+	on_mouse_down     string = 'on_mouse_down'
+	on_mouse_up       string = 'on_mouse_up'
+	on_key_down       string = 'on_key_down'
+	on_key_up         string = 'on_key_up'
+	on_scroll         string = 'on_scroll'
+	on_window_resized string = 'on_window_resized'
 }
 
 pub const (

--- a/window.v
+++ b/window.v
@@ -51,6 +51,8 @@ pub mut:
 	char_fn       KeyFn
 	mouse_move_fn MouseMoveFn
 	eventbus      &eventbus.EventBus = eventbus.new()
+	// resizable has limitation https://github.com/vlang/ui/issues/231
+	resizable bool // currently only for events.on_window_resized not modify children
 }
 
 pub struct WindowConfig {
@@ -109,6 +111,9 @@ fn on_event(e &sapp.Event, mut window Window) {
 		.mouse_move {
 			window_mouse_move(e, window.ui)
 		}
+		.resized {
+			window_resized(e, window.ui)
+		}
 		else {}
 	}
 	/*
@@ -159,6 +164,7 @@ pub fn window(cfg WindowConfig, children []Widget) &Window {
 		mouse_move_fn: cfg.on_mouse_move
 		mouse_down_fn: cfg.on_mouse_down
 		mouse_up_fn: cfg.on_mouse_up
+		resizable: cfg.resizable
 	}
 	gcontext := gg.new_context(
 		width: cfg.width
@@ -447,6 +453,14 @@ fn window_char(event sapp.Event, ui &UI) {
 	*/
 }
 
+fn window_resized(event sapp.Event, ui &UI) {
+	mut window := ui.window
+	if window.resizable {
+		window.resize(event.window_width, event.window_height)
+		window.eventbus.publish(events.on_window_resized, window, voidptr(0))
+	}
+}
+
 fn (mut w Window) focus_next() {
 	mut doit := false
 	for child in w.children {
@@ -661,7 +675,11 @@ fn (w &Window) size() (int, int) {
 	return w.width, w.height
 }
 
-fn (window &Window) resize(width int, height int) {
+fn (mut window Window) resize(width int, height int) {
+	window.width = width
+	window.height = height
+	// for mut child in window.children {
+	// }
 }
 
 fn (window &Window) unfocus_all() {


### PR DESCRIPTION
Added `on_window_resized` event to `ui.Window` as a workaround for layouting custom widgets, since `ui.Stack.resize()` is not implemented yet.

Setting `Window.resizable : true` publishes `on_window_resized` event.