### PR TITLE
dropdown.v: added selected() function

### DIFF
--- a/dropdown.v
+++ b/dropdown.v
@@ -74,20 +74,20 @@ fn (mut dd Dropdown) set_pos(x int, y int) {
 }
 
 fn (mut dd Dropdown) size() (int, int) {
-	return dd.width, dropdown_height
+	return dd.width, ui.dropdown_height
 }
 
 fn (mut dd Dropdown) propose_size(w int, h int) (int, int) {
 	dd.width = w
 	// dd.height = h
-	return w, dropdown_height
+	return w, ui.dropdown_height
 }
 
 fn (mut dd Dropdown) draw() {
 	gg := dd.ui.gg
 	// draw the main dropdown
-	gg.draw_rect(dd.x, dd.y, dd.width, dropdown_height, dropdown_color)
-	gg.draw_empty_rect(dd.x, dd.y, dd.width, dropdown_height, border_color)
+	gg.draw_rect(dd.x, dd.y, dd.width, ui.dropdown_height, ui.dropdown_color)
+	gg.draw_empty_rect(dd.x, dd.y, dd.width, ui.dropdown_height, ui.border_color)
 	if dd.selected_index >= 0 {
 		gg.draw_text_def(dd.x + 5, dd.y + 5, dd.items[dd.selected_index].text)
 	} else {
@@ -95,17 +95,18 @@ fn (mut dd Dropdown) draw() {
 	}
 	// draw the drawer
 	if dd.open {
-		gg.draw_rect(dd.x, dd.y + dropdown_height, dd.width, dd.items.len * dropdown_height,
-			drawer_color)
-		gg.draw_empty_rect(dd.x, dd.y + dropdown_height, dd.width, dd.items.len * dropdown_height,
-			border_color)
-		y := dd.y + dropdown_height
+		gg.draw_rect(dd.x, dd.y + ui.dropdown_height, dd.width, dd.items.len * ui.dropdown_height,
+			ui.drawer_color)
+		gg.draw_empty_rect(dd.x, dd.y + ui.dropdown_height, dd.width, dd.items.len * ui.dropdown_height,
+			ui.border_color)
+		y := dd.y + ui.dropdown_height
 		for i, item in dd.items {
-			color := if i == dd.hover_index { border_color } else { drawer_color }
-			gg.draw_rect(dd.x, y + i * dropdown_height, dd.width, dropdown_height, color)
-			gg.draw_empty_rect(dd.x, y + i * dropdown_height, dd.width, dropdown_height,
-				border_color)
-			gg.draw_text_def(dd.x + 5, y + i * dropdown_height + 5, item.text)
+			color := if i == dd.hover_index { ui.border_color } else { ui.drawer_color }
+			gg.draw_rect(dd.x, y + i * ui.dropdown_height, dd.width, ui.dropdown_height,
+				color)
+			gg.draw_empty_rect(dd.x, y + i * ui.dropdown_height, dd.width, ui.dropdown_height,
+				ui.border_color)
+			gg.draw_text_def(dd.x + 5, y + i * ui.dropdown_height + 5, item.text)
 		}
 	}
 	// draw the arrow
@@ -141,6 +142,11 @@ fn dd_key_down(mut dd Dropdown, e &KeyEvent, zzz voidptr) {
 		}
 		.enter {
 			dd.selected_index = dd.hover_index
+			if dd.on_selection_changed != voidptr(0) {
+				parent := dd.parent
+				state := parent.get_state()
+				dd.on_selection_changed(state, dd)
+			}
 			dd.unfocus()
 		}
 		else {}
@@ -151,10 +157,10 @@ fn dd_click(mut dd Dropdown, e &MouseEvent, zzz voidptr) {
 	if !dd.point_inside(e.x, e.y) || e.action == .down {
 		return
 	}
-	if e.y >= dd.y && e.y <= dd.y + dropdown_height && e.x >= dd.x && e.x <= dd.x + dd.width {
+	if e.y >= dd.y && e.y <= dd.y + ui.dropdown_height && e.x >= dd.x && e.x <= dd.x + dd.width {
 		dd.open_drawer()
 	} else if dd.open {
-		th := dd.y + (dd.items.len * dropdown_height)
+		th := dd.y + (dd.items.len * ui.dropdown_height)
 		index := ((e.y * dd.items.len) / th) - 1
 		dd.selected_index = index
 		if dd.on_selection_changed != voidptr(0) {
@@ -168,7 +174,7 @@ fn dd_click(mut dd Dropdown, e &MouseEvent, zzz voidptr) {
 
 fn dd_mouse_move(mut dd Dropdown, e &MouseEvent, zzz voidptr) {
 	if dd.open {
-		th := dd.y + (dd.items.len * dropdown_height)
+		th := dd.y + (dd.items.len * ui.dropdown_height)
 		index := ((e.y * dd.items.len) / th) - 1
 		dd.hover_index = index
 	}
@@ -196,6 +202,11 @@ fn (mut dd Dropdown) unfocus() {
 }
 
 fn (dd &Dropdown) point_inside(x f64, y f64) bool {
-	return y >= dd.y && y <= dd.y + (dd.items.len * dropdown_height) + dropdown_height && x >= dd.x
-		&& x <= dd.x + dd.width
+	return y >= dd.y && y <= dd.y + (dd.items.len * ui.dropdown_height) + ui.dropdown_height
+		&& x >= dd.x&& x <= dd.x + dd.width
+}
+
+// Returns the currently selected DropdownItem
+pub fn (dd &Dropdown) selected() DropdownItem {
+	return dd.items[dd.selected_index]
 }

--- a/examples/dropdown.v
+++ b/examples/dropdown.v
@@ -10,6 +10,10 @@ mut:
 	window &ui.Window = 0
 }
 
+fn dd_change(mut app App, dd &ui.Dropdown) {
+	println(dd.selected().text)
+}
+
 fn main() {
 	mut app := &App{}
 	window := ui.window({
@@ -22,6 +26,7 @@ fn main() {
 			stretch: true
 			alignment: .left
 			margin: ui.MarginConfig{5, 5, 5, 5}
+			on_selection_changed: dd_change
 		}, [
 			ui.dropdown({
 				width: 140

--- a/examples/dropdown.v
+++ b/examples/dropdown.v
@@ -26,11 +26,11 @@ fn main() {
 			stretch: true
 			alignment: .left
 			margin: ui.MarginConfig{5, 5, 5, 5}
-			on_selection_changed: dd_change
 		}, [
 			ui.dropdown({
 				width: 140
 				def_text: 'Select an option'
+				on_selection_changed: dd_change
 			}, [
 				ui.DropdownItem{
 					text: 'Delete all users'


### PR DESCRIPTION
Added a new function to [dropdown.v](https://github.com/vlang/ui/blob/master/dropdown.v), selected(), which returns the currently selected DropdownItem.

selected():
```v
// Returns the currently selected DropdownItem
pub fn (dd &Dropdown) selected() DropdownItem {
	return dd.items[dd.selected_index]
}
```

Also made a minor fix in the same file, on which selecting an element by pressing enter didn't call dd.on_selection_changed() (if this function is present, that is).

Finally, I edited the dropdown example to show this new function, and vfmt-d both files.