### PR TITLE
introduce ui.compact to inherit size from children

### DIFF
--- a/button.v
+++ b/button.v
@@ -33,7 +33,7 @@ pub struct ButtonConfig {
 	width     int
 }
 
-[ref_only]
+[heap]
 pub struct Button {
 mut:
 	text_width  int

--- a/checkbox.v
+++ b/checkbox.v
@@ -19,7 +19,7 @@ enum CheckBoxState {
 */
 type CheckChangedFn = fn (voidptr, bool)
 
-[ref_only]
+[heap]
 pub struct CheckBox {
 pub mut:
 	// state      CheckBoxState

--- a/column.v
+++ b/column.v
@@ -14,19 +14,21 @@ pub struct ColumnConfig {
 	widths     Size    //[]f64 // children sizes
 	heights    Size //[]f64
 	alignments HorizontalAlignments
+	align      Alignments
 }
 
 pub fn column(c ColumnConfig, children []Widget) &Stack {
 	return stack({
 		height: c.height
 		width: c.width
-		heights: c.heights.as_f32_array(children.len) //.map(f32(it))
-		widths: c.widths.as_f32_array(children.len) //.map(f32(it))
 		horizontal_alignment: c.alignment
-		horizontal_alignments: c.alignments
 		spacing: c.spacing.as_int_array(children.len - 1)
 		stretch: c.stretch
 		direction: .column
 		margin: c.margin.as_margin()
+		heights: c.heights.as_f32_array(children.len) //.map(f32(it))
+		widths: c.widths.as_f32_array(children.len) //.map(f32(it))
+		horizontal_alignments: c.alignments
+		align: c.align
 	}, children)
 }

--- a/column.v
+++ b/column.v
@@ -4,8 +4,8 @@
 module ui
 
 pub struct ColumnConfig {
-	width     f32 // To remove soon
-	height    f32 // To remove soon
+	width     int // To remove soon
+	height    int // To remove soon
 	alignment HorizontalAlignment
 	spacing   Spacing = Spacing(0) // int
 	stretch   bool

--- a/const.v
+++ b/const.v
@@ -7,6 +7,7 @@ pub:
 	on_mouse_down string = 'on_mouse_down'
 	on_mouse_up   string = 'on_mouse_up'
 	on_key_down   string = 'on_key_down'
+	on_char       string = 'on_char'
 	on_key_up     string = 'on_key_up'
 	on_scroll     string = 'on_scroll'
 	on_resize     string = 'on_resize'

--- a/examples/calculator.v
+++ b/examples/calculator.v
@@ -53,8 +53,7 @@ fn main() {
 		state: app
 	}, [
 		ui.column({
-			stretch: true
-			margin: ui.Margin{5, 5, 5, 5}
+			margin: 5
 			spacing: 5
 		}, children),
 	])

--- a/examples/change_title.v
+++ b/examples/change_title.v
@@ -20,9 +20,10 @@ fn main() {
 		state: app
 	}, [
 		ui.column({
-			stretch: true
 			spacing: 20
 			margin: 30
+			// uncomment if you don't set the width of the button
+			// widths: [ui.stretch,150] 
 		}, [
 			ui.row({
 				spacing: 10
@@ -37,7 +38,7 @@ fn main() {
 					is_focused: true
 				),
 			]),
-			ui.button(text: 'Change title', onclick: btn_change_title),
+			ui.button(text: 'Change title', onclick: btn_change_title, width: 150),
 		]),
 	])
 	ui.run(app.window)

--- a/examples/counter.v
+++ b/examples/counter.v
@@ -21,10 +21,8 @@ fn main() {
 		state: app
 	}, [
 		ui.row({
-			alignment: .top
 			spacing: 5
-			stretch: true
-			margin: ui.Margin{5, 5, 5, 5}
+			margin: 5
 		}, [
 			ui.textbox(
 				max_len: 20

--- a/examples/dropdown.v
+++ b/examples/dropdown.v
@@ -23,9 +23,7 @@ fn main() {
 		state: app
 	}, [
 		ui.column({
-			stretch: true
-			alignment: .left
-			margin: ui.Margin{5, 5, 5, 5}
+			margin: 5
 		}, [
 			ui.dropdown({
 				width: 140

--- a/examples/group2.v
+++ b/examples/group2.v
@@ -22,7 +22,6 @@ fn main() {
 		state: app
 	}, [
 		ui.column({
-			stretch: true
 			margin: 10
 		}, [
 			ui.row({

--- a/examples/rgb_color.v
+++ b/examples/rgb_color.v
@@ -120,7 +120,7 @@ fn main() {
 				// right: 20
 				// bottom: 20
 			}
-			heights: [.3,.1,.5,.1]
+			heights: [.3, .1, .5, .1]
 			alignments: {
 				center: [0, 1, 2, 3]
 			}

--- a/examples/rgb_color.v
+++ b/examples/rgb_color.v
@@ -45,7 +45,7 @@ fn main() {
 			max_len: 3
 			read_only: false
 			is_numeric: true
-			on_key_up: on_r_key_up
+			on_char: on_r_char
 			text: -1
 		)
 		g_textbox: ui.textbox(
@@ -54,7 +54,7 @@ fn main() {
 			max_len: 3
 			read_only: false
 			is_numeric: true
-			on_key_up: on_g_key_up
+			on_char: on_g_char
 			text: -1
 		)
 		b_textbox: ui.textbox(
@@ -63,7 +63,7 @@ fn main() {
 			max_len: 3
 			read_only: false
 			is_numeric: true
-			on_key_up: on_b_key_up
+			on_char: on_b_char
 			text: -1
 		)
 		r_slider: ui.slider(
@@ -153,7 +153,7 @@ fn on_b_value_changed(mut app App, slider &ui.Slider) {
 	textbox_color_update(mut app)
 }
 
-fn on_r_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
+fn on_r_char(mut app App, textbox &ui.TextBox, keycode u32) {
 	if is_rgb_valid(app.r_textbox.text.int()) {
 		app.r_slider.val = app.r_textbox_text.f32()
 		app.r_textbox.border_accentuated = false
@@ -163,7 +163,7 @@ fn on_r_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
 	textbox_color_update(mut app)
 }
 
-fn on_g_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
+fn on_g_char(mut app App, textbox &ui.TextBox, keycode u32) {
 	if is_rgb_valid(app.g_textbox.text.int()) {
 		app.g_slider.val = app.g_textbox_text.f32()
 		app.g_textbox.border_accentuated = false
@@ -173,7 +173,7 @@ fn on_g_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
 	textbox_color_update(mut app)
 }
 
-fn on_b_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
+fn on_b_char(mut app App, textbox &ui.TextBox, keycode u32) {
 	if is_rgb_valid(app.b_textbox.text.int()) {
 		app.b_slider.val = app.b_textbox_text.f32()
 		app.b_textbox.border_accentuated = false

--- a/examples/rgb_color.v
+++ b/examples/rgb_color.v
@@ -115,8 +115,12 @@ fn main() {
 		ui.column({
 			spacing: 0
 			margin: ui.Margin{
-				top: 20
+				top: 40
+				// left: 20
+				// right: 20
+				// bottom: 20
 			}
+			heights: [.3,.1,.5,.1]
 			alignments: {
 				center: [0, 1, 2, 3]
 			}
@@ -126,6 +130,9 @@ fn main() {
 		}, [app.r_textbox, app.g_textbox, app.b_textbox]), ui.row({
 			margin: 30
 			spacing: 38
+			// alignments: {
+			// 	top: [0,1,2]
+			// }
 		}, [app.r_slider, app.g_slider, app.b_slider]), ui.row({
 			margin: 30
 			spacing: 54

--- a/examples/rgb_color.v
+++ b/examples/rgb_color.v
@@ -114,26 +114,22 @@ fn main() {
 	}, [
 		ui.column({
 			spacing: 0
-			margin: ui.Margin{30, 30, 30, 30}
-			alignment: .center
-		}, [
-			app.rgb_rectangle,
-			ui.row({
-				alignment: .top
-				margin: ui.Margin{30, 30, 30, 30}
-				spacing: 23
-			}, [app.r_textbox, app.g_textbox, app.b_textbox]),
-			ui.row({
-				alignment: .top
-				margin: ui.Margin{30, 30, 30, 30}
-				spacing: 38
-			}, [app.r_slider, app.g_slider, app.b_slider]),
-			ui.row({
-				alignment: .top
-				margin: ui.Margin{30, 30, 30, 30}
-				spacing: 54
-			}, [app.r_label, app.g_label, app.b_label]),
-		]),
+			margin: ui.Margin{
+				top: 20
+			}
+			alignments: {
+				center: [0, 1, 2, 3]
+			}
+		}, [app.rgb_rectangle, ui.row({
+			margin: 30
+			spacing: 23
+		}, [app.r_textbox, app.g_textbox, app.b_textbox]), ui.row({
+			margin: 30
+			spacing: 38
+		}, [app.r_slider, app.g_slider, app.b_slider]), ui.row({
+			margin: 30
+			spacing: 54
+		}, [app.r_label, app.g_label, app.b_label])]),
 	])
 	ui.run(app.window)
 }

--- a/examples/slider.v
+++ b/examples/slider.v
@@ -39,7 +39,6 @@ fn main() {
 		state: app
 	}, [
 		ui.row({
-			stretch: true
 			alignment: .center
 			margin: 5
 			spacing: 10

--- a/examples/slider_textbox.v
+++ b/examples/slider_textbox.v
@@ -76,25 +76,22 @@ fn main() {
 	}, [
 		ui.column({
 			widths: 1.
-			heights: [.1,.9]
+			heights: [.1, .9]
+			// spacing: 30
+		}, [ui.row({
+			// align: {
+			// 	center: [0, 1]
+			// }
+			// margin: ui.Margin{50, 115, 30, 30}
+			// spacing: 100
+		}, [app.hor_textbox, app.vert_textbox]), ui.row({
+			// align: {
+			// 	center: [0]
+			// 	top: [1]
+			// }
+			margin: ui.Margin{100, 30, 30, 30}
 			spacing: 30
-		}, [
-			ui.row({
-				align: {
-					center: [0, 1]
-				}
-				// margin: ui.Margin{50, 115, 30, 30}
-				// spacing: 100
-			}, [app.hor_textbox, app.vert_textbox]),
-			ui.row({
-				align: {
-					center: [0]
-					top: [1]
-				}
-				margin: ui.Margin{100, 30, 30, 30}
-				spacing: 30
-			}, [app.hor_slider, app.vert_slider]),
-		])
+		}, [app.hor_slider, app.vert_slider])]),
 	])
 	ui.run(app.window)
 }

--- a/examples/slider_textbox.v
+++ b/examples/slider_textbox.v
@@ -34,7 +34,7 @@ fn main() {
 			val: hor_slider_val
 			focus_on_thumb_only: true
 			rev_min_max_pos: true
-			on_value_changed: on_hor_value_changed
+			on_value_changed: on_value_changed_hor
 		)
 		vert_slider: ui.slider(
 			width: 10
@@ -45,7 +45,7 @@ fn main() {
 			val: vert_slider_val
 			focus_on_thumb_only: true
 			rev_min_max_pos: true
-			on_value_changed: on_vert_value_changed
+			on_value_changed: on_value_changed_vert
 		)
 		hor_textbox: ui.textbox(
 			width: 40
@@ -54,7 +54,7 @@ fn main() {
 			read_only: false
 			is_numeric: true
 			text: -1
-			on_key_up: on_hor_key_up
+			on_char: on_char_hor
 		)
 		vert_textbox: ui.textbox(
 			width: 40
@@ -63,7 +63,7 @@ fn main() {
 			read_only: false
 			is_numeric: true
 			text: -1
-			on_key_up: on_vert_key_up
+			on_char: on_char_vert
 		)
 	}
 	app.hor_textbox.text = &app.hor_text
@@ -88,17 +88,17 @@ fn main() {
 	ui.run(app.window)
 }
 
-fn on_hor_value_changed(mut app App, slider &ui.Slider) {
+fn on_value_changed_hor(mut app App, slider &ui.Slider) {
 	app.hor_text = int(app.hor_slider.val).str()
 	app.hor_textbox.border_accentuated = false
 }
 
-fn on_vert_value_changed(mut app App, slider &ui.Slider) {
+fn on_value_changed_vert(mut app App, slider &ui.Slider) {
 	app.vert_text = int(app.vert_slider.val).str()
 	app.vert_textbox.border_accentuated = false
 }
 
-fn on_hor_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
+fn on_char_hor(mut app App, textbox &ui.TextBox, keycode u32) {
 	val := app.hor_text.int()
 	min := app.hor_slider.min
 	max := app.hor_slider.max
@@ -110,7 +110,7 @@ fn on_hor_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
 	}
 }
 
-fn on_vert_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
+fn on_char_vert(mut app App, textbox &ui.TextBox, keycode u32) {
 	val := app.vert_text.int()
 	min := app.vert_slider.min
 	max := app.vert_slider.max

--- a/examples/slider_textbox.v
+++ b/examples/slider_textbox.v
@@ -74,16 +74,27 @@ fn main() {
 		title: 'Slider & textbox Example'
 		state: app
 	}, [
-		ui.row({
-			alignment: .top
-			margin: ui.Margin{50, 115, 30, 30}
-			spacing: 100
-		}, [app.hor_textbox, app.vert_textbox]),
-		ui.row({
-			alignment: .top
-			margin: ui.Margin{100, 30, 30, 30}
+		ui.column({
+			widths: 1.
+			heights: [.1,.9]
 			spacing: 30
-		}, [app.hor_slider, app.vert_slider]),
+		}, [
+			ui.row({
+				align: {
+					center: [0, 1]
+				}
+				// margin: ui.Margin{50, 115, 30, 30}
+				// spacing: 100
+			}, [app.hor_textbox, app.vert_textbox]),
+			ui.row({
+				align: {
+					center: [0]
+					top: [1]
+				}
+				margin: ui.Margin{100, 30, 30, 30}
+				spacing: 30
+			}, [app.hor_slider, app.vert_slider]),
+		])
 	])
 	ui.run(app.window)
 }

--- a/examples/switch.v
+++ b/examples/switch.v
@@ -27,7 +27,6 @@ fn main() {
 		ui.row({
 			alignment: .top
 			spacing: 5
-			stretch: true
 			margin: ui.Margin{5, 5, 5, 5}
 		}, [
 			app.label,

--- a/examples/temperature.v
+++ b/examples/temperature.v
@@ -18,13 +18,13 @@ fn main() {
 	mut app := &App{
 		txt_box_celsius: ui.textbox(
 			width: 70
-			on_key_up: on_cel_key_up
+			on_char: on_char_celsius
 			is_numeric: true
 			text: -1
 		)
 		txt_box_fahrenheit: ui.textbox(
 			width: 70
-			on_key_up: on_fah_key_up
+			on_char: on_char_fahrenheit
 			is_numeric: true
 			text: -1
 		)
@@ -39,9 +39,7 @@ fn main() {
 		state: app
 	}, [
 		ui.row({
-			stretch: true
-			alignment: .center
-			margin: ui.Margin{5, 5, 5, 5}
+			margin: 5
 			spacing: 10
 		}, [
 			ui.label(text: 'Celsius'),
@@ -53,7 +51,7 @@ fn main() {
 	ui.run(app.window)
 }
 
-fn on_cel_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
+fn on_char_celsius(mut app App, textbox &ui.TextBox, keycode u32) {
 	if app.txt_box_celsius.text.len <= 0 {
 		app.txt_box_fahrenheit_text = '0'
 		return
@@ -63,7 +61,7 @@ fn on_cel_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
 	app.txt_box_fahrenheit_text = int(fah).str()
 }
 
-fn on_fah_key_up(mut app App, textbox &ui.TextBox, keycode u32) {
+fn on_char_fahrenheit(mut app App, textbox &ui.TextBox, keycode u32) {
 	if app.txt_box_fahrenheit.text.len <= 0 {
 		app.txt_box_celsius_text = '0'
 		return

--- a/examples/timer.v
+++ b/examples/timer.v
@@ -39,6 +39,7 @@ fn main() {
 	}, [
 		ui.column({
 			// stretch: true
+			widths: [ui.stretch,ui.stretch]
 			margin: 5
 			alignments: {
 				left: [0]

--- a/examples/timer.v
+++ b/examples/timer.v
@@ -38,32 +38,31 @@ fn main() {
 		state: app
 	}, [
 		ui.column({
-			stretch: true
-			margin: ui.Margin{5, 5, 5, 5}
-			alignment: .left
+			// stretch: true
+			margin: 5
+			alignments: {
+				left: [0]
+				center: [1]
+			}
+			widths: 1.
+			heights: [.9, .1]
+			spacing: 30
+		}, [ui.row({
+			spacing: 10
+			widths: [.3, .7]
+		}, [ui.column({
+			spacing: 10
+			heights: ui.compact
 		}, [
-			ui.row({
-				alignment: .top
-				spacing: 10
-			}, [
-				ui.column({
-					alignment: .left
-					spacing: 10
-				}, [
-					ui.label(text: 'Elapsed Time:'),
-					ui.label(text: 'Duration:'),
-					ui.button(text: 'Reset', onclick: on_reset),
-				]),
-				ui.column({
-					alignment: .left
-					spacing: 10
-				}, [
-					app.lbl_elapsed_value,
-					app.slider,
-				]),
-			]),
-			app.progress_bar,
-		]),
+			ui.label(text: 'Elapsed Time:'),
+			ui.label(text: 'Duration:'),
+			ui.button(text: 'Reset', onclick: on_reset),
+		]), ui.column({
+			spacing: 10
+		}, [
+			app.lbl_elapsed_value,
+			app.slider,
+		])]), app.progress_bar]),
 	])
 	app.window = window
 	go app.timer()

--- a/examples/timer.v
+++ b/examples/timer.v
@@ -45,7 +45,6 @@ fn main() {
 				center: [1]
 			}
 			spacing: 10
-			heights: ui.compact
 		}, [
 			ui.row({
 				spacing: 10

--- a/examples/timer.v
+++ b/examples/timer.v
@@ -45,26 +45,21 @@ fn main() {
 				center: [1]
 			}
 			spacing: 10
+		}, [ui.row({
+			spacing: 10
+			widths: [.3, .7]
+		}, [ui.column({
+			spacing: 10
 		}, [
-			ui.row({
-				spacing: 10
-				widths: [.3, .7]
-			}, [
-				ui.column({
-				spacing: 10
-				}, [
-					ui.label(text: 'Elapsed Time:'),
-					ui.label(text: 'Duration:'),
-					ui.button(text: 'Reset', onclick: on_reset),
-				]), 
-				ui.column({
-					spacing: 10
-				}, [
-					app.lbl_elapsed_value,
-					app.slider,
-				])]), 
-			app.progress_bar
-		]),
+			ui.label(text: 'Elapsed Time:'),
+			ui.label(text: 'Duration:'),
+			ui.button(text: 'Reset', onclick: on_reset),
+		]), ui.column({
+			spacing: 10
+		}, [
+			app.lbl_elapsed_value,
+			app.slider,
+		])]), app.progress_bar]),
 	])
 	app.window = window
 	go app.timer()

--- a/examples/timer.v
+++ b/examples/timer.v
@@ -3,7 +3,7 @@ import time
 
 const (
 	win_width  = 287
-	win_height = 110
+	win_height = 130
 )
 
 struct App {
@@ -44,15 +44,12 @@ fn main() {
 				left: [0]
 				center: [1]
 			}
-			widths: 1.
-			heights: [.9, .1]
-			spacing: 30
+			spacing: 10
 		}, [ui.row({
 			spacing: 10
 			widths: [.3, .7]
 		}, [ui.column({
 			spacing: 10
-			heights: ui.compact
 		}, [
 			ui.label(text: 'Elapsed Time:'),
 			ui.label(text: 'Duration:'),

--- a/examples/timer.v
+++ b/examples/timer.v
@@ -45,21 +45,27 @@ fn main() {
 				center: [1]
 			}
 			spacing: 10
-		}, [ui.row({
-			spacing: 10
-			widths: [.3, .7]
-		}, [ui.column({
-			spacing: 10
+			heights: ui.compact
 		}, [
-			ui.label(text: 'Elapsed Time:'),
-			ui.label(text: 'Duration:'),
-			ui.button(text: 'Reset', onclick: on_reset),
-		]), ui.column({
-			spacing: 10
-		}, [
-			app.lbl_elapsed_value,
-			app.slider,
-		])]), app.progress_bar]),
+			ui.row({
+				spacing: 10
+				widths: [.3, .7]
+			}, [
+				ui.column({
+				spacing: 10
+				}, [
+					ui.label(text: 'Elapsed Time:'),
+					ui.label(text: 'Duration:'),
+					ui.button(text: 'Reset', onclick: on_reset),
+				]), 
+				ui.column({
+					spacing: 10
+				}, [
+					app.lbl_elapsed_value,
+					app.slider,
+				])]), 
+			app.progress_bar
+		]),
 	])
 	app.window = window
 	go app.timer()

--- a/examples/users.v
+++ b/examples/users.v
@@ -73,93 +73,92 @@ fn main() {
 	}, [
 		ui.row({
 			margin: 10
+			widths: [.25, .75]
+			spacing: 10
+		}, [ui.column({
+			spacing: 13
 		}, [
-			ui.column({
-				width: .25
-				spacing: 13
+			ui.textbox(
+				max_len: 20
+				width: 200
+				placeholder: 'First name'
+				text: &app.first_name
+				// is_focused: &app.started
+				is_error: &app.is_error
+				is_focused: true
+			),
+			ui.textbox(
+				max_len: 50
+				width: 200
+				placeholder: 'Last name'
+				text: &app.last_name
+				is_error: &app.is_error
+			),
+			ui.textbox(
+				max_len: 3
+				width: 200
+				placeholder: 'Age'
+				is_numeric: true
+				text: &app.age
+				is_error: &app.is_error
+			),
+			ui.textbox(
+				width: 200
+				placeholder: 'Password'
+				is_password: true
+				max_len: 20
+				text: &app.password
+			),
+			ui.checkbox(
+				checked: true
+				text: 'Online registration'
+			),
+			ui.checkbox(
+				text: 'Subscribe to the newsletter'
+			),
+			app.country,
+			ui.row({
+				spacing: 65
 			}, [
-				ui.textbox(
-					max_len: 20
-					width: 200
-					placeholder: 'First name'
-					text: &app.first_name
-					// is_focused: &app.started
-					is_error: &app.is_error
-					is_focused: true
+				ui.button(
+					text: 'Add user'
+					onclick: btn_add_click
 				),
-				ui.textbox(
-					max_len: 50
-					width: 200
-					placeholder: 'Last name'
-					text: &app.last_name
-					is_error: &app.is_error
-				),
-				ui.textbox(
-					max_len: 3
-					width: 200
-					placeholder: 'Age'
-					is_numeric: true
-					text: &app.age
-					is_error: &app.is_error
-				),
-				ui.textbox(
-					width: 200
-					placeholder: 'Password'
-					is_password: true
-					max_len: 20
-					text: &app.password
-				),
-				ui.checkbox(
-					checked: true
-					text: 'Online registration'
-				),
-				ui.checkbox(
-					text: 'Subscribe to the newsletter'
-				),
-				app.country,
-				ui.row({
-					spacing: 65
-				}, [
-					ui.button(
-						text: 'Add user'
-						onclick: btn_add_click
-					),
-					ui.button(
-						text: '?'
-						onclick: btn_help_click
-					),
-				]),
-				ui.row({
-					spacing: 5
-					alignment: .center
-				}, [
-					app.pbar,
-					app.label,
-				]),
-			]),
-			ui.column({
-				// stretch: true
-				width: .75
-				alignment: .right
-			}, [
-				ui.canvas(
-					width: 450
-					height: 275
-					draw_fn: canvas_draw
-				),
-				ui.picture(
-					width: 100
-					height: 100
-					path: os.resource_abs_path('logo.png')
+				ui.button(
+					text: '?'
+					onclick: btn_help_click
 				),
 			]),
-		]),
+			ui.row({
+				spacing: 5
+			}, [
+				app.pbar,
+				app.label,
+			]),
+		]), ui.column({
+			alignments: {
+				center: [
+					0,
+				]
+				right: [
+					1,
+				]
+			}
+		}, [
+			ui.canvas(
+				width: 400
+				height: 275
+				draw_fn: canvas_draw
+			),
+			ui.picture(
+				width: 100
+				height: 100
+				path: os.resource_abs_path('logo.png')
+			),
+		])]),
 		ui.menu(
-			items: [
-				ui.MenuItem{'Delete all users', menu_click},
-				ui.MenuItem{'Export users', menu_click},
-				ui.MenuItem{'Exit', menu_click},
-			]
+			items: [ui.MenuItem{'Delete all users', menu_click},
+				ui.MenuItem{'Export users', menu_click}, ui.MenuItem{'Exit', menu_click}]
 		),
 	])
 	app.window = window

--- a/label.v
+++ b/label.v
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file.
 module ui
 
-[ref_only]
+[heap]
 pub struct Label {
 mut:
 	text   string

--- a/progressbar.v
+++ b/progressbar.v
@@ -12,7 +12,7 @@ const (
 	progress_bar_background_border_color = gx.rgb(191, 191, 191)
 )
 
-[ref_only]
+[heap]
 pub struct ProgressBar {
 pub mut:
 	height     int

--- a/radio.v
+++ b/radio.v
@@ -13,7 +13,7 @@ enum RadioState {
 */
 type RadioClickFn = fn ()
 
-[ref_only]
+[heap]
 pub struct Radio {
 pub mut:
 	selected_index int

--- a/row.v
+++ b/row.v
@@ -5,8 +5,8 @@ module ui
 
 pub struct RowConfig {
 pub:
-	width     f32
-	height    f32
+	width     int
+	height    int
 	alignment VerticalAlignment
 	spacing   Spacing = Spacing(0) // int
 	stretch   bool

--- a/row.v
+++ b/row.v
@@ -14,6 +14,7 @@ pub:
 	// children related
 	widths     Size //[]f64 // children sizes
 	heights    Size //[]f64
+	align      Alignments
 	alignments VerticalAlignments
 }
 
@@ -21,13 +22,14 @@ pub fn row(c RowConfig, children []Widget) &Stack {
 	return stack({
 		height: c.height
 		width: c.width
-		widths: c.widths.as_f32_array(children.len) //.map(f32(it))
-		heights: c.heights.as_f32_array(children.len) //.map(f32(it))
 		vertical_alignment: c.alignment
-		vertical_alignments: c.alignments
 		spacing: c.spacing.as_int_array(children.len - 1)
 		stretch: c.stretch
 		direction: .row
 		margin: c.margin.as_margin()
+		widths: c.widths.as_f32_array(children.len) //.map(f32(it))
+		heights: c.heights.as_f32_array(children.len) //.map(f32(it))
+		vertical_alignments: c.alignments
+		align: c.align
 	}, children)
 }

--- a/slider.v
+++ b/slider.v
@@ -79,13 +79,15 @@ pub fn slider(c SliderConfig) &Slider {
 		track_line_displayed: c.track_line_displayed
 		ui: 0
 	}
-	if !c.thumb_in_track {
-		s.thumb_height = if s.orientation == .horizontal { s.track_height + 10 } else { 10 }
-		s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width + 10 }
-	} else {
-		s.thumb_height = if s.orientation == .horizontal { s.track_height - 3 } else { 10 }
-		s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width - 3 }
-	}
+	s.set_thumb_size()
+	// if !c.thumb_in_track {
+	// 	s.thumb_height = if s.orientation == .horizontal { s.track_height + 10 } else { 10 }
+	// 	s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width + 10 }
+	// } else {
+	// 	s.thumb_height = if s.orientation == .horizontal { s.track_height - 3 } else { 10 }
+	// 	s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width - 3 }
+	// }
+	
 	if s.min > s.max {
 		tmp := s.max
 		s.max = s.min
@@ -126,6 +128,16 @@ fn (mut s Slider) set_pos(x int, y int) {
 	s.y = y
 }
 
+fn (mut s Slider) set_thumb_size() {
+	if !s.thumb_in_track {
+		s.thumb_height = if s.orientation == .horizontal { s.track_height + 10 } else { 10 }
+		s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width + 10 }
+	} else {
+		s.thumb_height = if s.orientation == .horizontal { s.track_height - 3 } else { 10 }
+		s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width - 3 }
+	}
+}
+
 fn (mut s Slider) size() (int, int) {
 	if s.orientation == .horizontal {
 		return s.track_width, s.thumb_height
@@ -135,19 +147,16 @@ fn (mut s Slider) size() (int, int) {
 }
 
 fn (mut s Slider) propose_size(w int, h int) (int, int) {
-	//
-	s.track_width = w
-	s.track_height = h
-	// if s.track_height > 20 {s.track_height = 20} //TODO constrain
-	s.thumb_height = if s.orientation == .horizontal { s.track_height + 10 } else { 10 }
-	s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width + 10 }
-	// return w, s.thumb_height
-	//
+	// TODO: fix
+	println("slider propose_size: (${s.track_width},${s.track_height}) -> ($w, $h) ")
 	if s.orientation == .horizontal {
-		return s.track_width, s.thumb_height
+		s.track_width = w
 	} else {
-		return s.thumb_width, s.track_height
+		s.track_height = h
 	}
+	s.set_thumb_size()
+	return s.size()
+
 }
 
 fn (s &Slider) draw() {
@@ -213,7 +222,6 @@ fn (s &Slider) point_inside(x f64, y f64) bool {
 
 fn slider_click(mut s Slider, e &MouseEvent, zzz voidptr) {
 	if !s.point_inside_thumb(e.x, e.y) && (!s.point_inside(e.x, e.y) || s.focus_on_thumb_only) {
-		s.dragging = false
 		s.is_focused = false
 		return
 	}
@@ -221,11 +229,17 @@ fn slider_click(mut s Slider, e &MouseEvent, zzz voidptr) {
 		s.change_value(e.x, e.y)
 	}
 	s.is_focused = true
-	// s.dragging = e.action == .down
 }
 
 fn slider_mouse_move(mut s Slider, e &MouseMoveEvent, zzz voidptr) {
-	if int(e.mouse_button) > 0 && s.point_inside(e.x, e.y) {
+	if int(e.mouse_button) > 0 {
+		if s.point_inside_thumb(e.x, e.y) {
+			s.dragging = true
+		}
+	} else {
+		s.dragging = false
+	}
+	if s.dragging {
 		s.change_value(int(e.x), int(e.y))
 	}
 }

--- a/slider.v
+++ b/slider.v
@@ -87,7 +87,7 @@ pub fn slider(c SliderConfig) &Slider {
 	// 	s.thumb_height = if s.orientation == .horizontal { s.track_height - 3 } else { 10 }
 	// 	s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width - 3 }
 	// }
-	
+
 	if s.min > s.max {
 		tmp := s.max
 		s.max = s.min
@@ -148,7 +148,9 @@ fn (mut s Slider) size() (int, int) {
 
 fn (mut s Slider) propose_size(w int, h int) (int, int) {
 	// TODO: fix
-	println("slider propose_size: (${s.track_width},${s.track_height}) -> ($w, $h) ")
+	$if debug_slider ? {
+		println('slider propose_size: ($s.track_width,$s.track_height) -> ($w, $h) ')
+	}
 	if s.orientation == .horizontal {
 		s.track_width = w
 	} else {
@@ -156,7 +158,6 @@ fn (mut s Slider) propose_size(w int, h int) (int, int) {
 	}
 	s.set_thumb_size()
 	return s.size()
-
 }
 
 fn (s &Slider) draw() {

--- a/slider.v
+++ b/slider.v
@@ -16,7 +16,7 @@ pub enum Orientation {
 	horizontal = 1
 }
 
-[ref_only]
+[heap]
 pub struct Slider {
 pub mut:
 	track_height         int

--- a/slider.v
+++ b/slider.v
@@ -135,14 +135,14 @@ fn (mut s Slider) size() (int, int) {
 }
 
 fn (mut s Slider) propose_size(w int, h int) (int, int) {
-	/*
+	//
 	s.track_width = w
 	s.track_height = h
-	if s.track_height > 20 {s.track_height = 20} //TODO constrain
-	s.thumb_height = if s.orientation == .horizontal {s.track_height + 10} else {10}
-	s.thumb_width = if s.orientation == .horizontal { 10 } else {s.track_width + 10}
-	return w, s.thumb_height
-	*/
+	// if s.track_height > 20 {s.track_height = 20} //TODO constrain
+	s.thumb_height = if s.orientation == .horizontal { s.track_height + 10 } else { 10 }
+	s.thumb_width = if s.orientation == .horizontal { 10 } else { s.track_width + 10 }
+	// return w, s.thumb_height
+	//
 	if s.orientation == .horizontal {
 		return s.track_width, s.thumb_height
 	} else {

--- a/stack.v
+++ b/stack.v
@@ -336,9 +336,10 @@ fn (mut s Stack) set_cache_sizes() {
 fn (s &Stack) alloc_children_sizes() ([]int, []int) {
 	mut mcw, mut mch := []int{}, []int{}
 	// free size without margin and spacing
-	// free_width, free_height := s.free_size()
-	c := &s.cache
-	
+	free_width, free_height := s.free_size()
+	// c := &s.cache
+
+
 	return mcw, mch
 }
 

--- a/stack.v
+++ b/stack.v
@@ -336,7 +336,7 @@ fn (mut s Stack) set_cache_sizes() {
 fn (s &Stack) alloc_children_sizes() ([]int, []int) {
 	mut mcw, mut mch := []int{}, []int{}
 	// free size without margin and spacing
-	free_width, free_height := s.free_size()
+	// free_width, free_height := s.free_size()
 	// c := &s.cache
 
 

--- a/stack.v
+++ b/stack.v
@@ -46,32 +46,36 @@ struct StackConfig {
 	// children related
 	widths                []f32   // children sizes
 	heights               []f32
+	align                 Alignments
 	vertical_alignments   VerticalAlignments
 	horizontal_alignments HorizontalAlignments
 }
 
 struct Stack {
+	cache                 CachedSizes
 mut:
 	x                     int
 	y                     int
 	width                 int
 	height                int
-	widths                []f32 // children sizes
-	heights               []f32
-	children              []Widget
 	parent                Layout
 	root                  &Window = voidptr(0)
 	ui                    &UI
 	vertical_alignment    VerticalAlignment
 	horizontal_alignment  HorizontalAlignment
-	vertical_alignments   VerticalAlignments // Flexible alignments by index overriding alignment.
-	horizontal_alignments HorizontalAlignments
 	spacing               []int // int
 	stretch               bool
 	direction             Direction
 	margin                Margin
 	adj_width             int
 	adj_height            int
+	// children related
+	children              []Widget
+	widths                []f32 // children sizes
+	heights               []f32
+	vertical_alignments   VerticalAlignments // Flexible alignments by index overriding alignment.
+	horizontal_alignments HorizontalAlignments
+	alignments            Alignments
 }
 
 fn stack(c StackConfig, children []Widget) &Stack {
@@ -79,17 +83,18 @@ fn stack(c StackConfig, children []Widget) &Stack {
 	mut s := &Stack{
 		height: c.height // TODO to remove
 		width: c.width // TODO to remove
-		widths: c.widths
-		heights: c.heights
 		vertical_alignment: c.vertical_alignment
 		horizontal_alignment: c.horizontal_alignment
-		vertical_alignments: c.vertical_alignments
-		horizontal_alignments: c.horizontal_alignments
 		spacing: c.spacing.as_int_array(children.len - 1)
 		stretch: c.stretch
 		direction: c.direction
 		margin: c.margin.as_margin()
 		children: children
+		widths: c.widths
+		heights: c.heights
+		vertical_alignments: c.vertical_alignments
+		horizontal_alignments: c.horizontal_alignments
+		alignments: c.align
 		ui: 0
 	}
 	return s
@@ -100,9 +105,28 @@ fn (mut s Stack) init(parent Layout) {
 	mut ui := parent.get_ui()
 	s.ui = ui
 
-	// Before position all sizes need to be determined
-	s.set_all_sizes(parent)
+	s.init_size(parent)
 
+	if parent is Window {
+		s.root = parent
+		// Only once for all children recursively
+		// 1) find all the adjusted sizes
+		s.set_adjusted_size(0, true, s.ui)
+		// 2) set cache sizes
+		s.set_cache_sizes()
+		$if debug_cache ? {
+			s.debug_show_cache(0)
+		}
+		// 3) set all the sizes (could be updated possibly for resizing)
+		s.set_children_sizes(parent)
+	} else if parent is Stack {
+		s.root = parent.root
+	}
+
+	// 2) set all the sizes
+		// s.set_children_sizes(parent)
+
+	// All sizes have to be set before positionning widgets
 	// Set the position of this stack (anchor could possibly be defined inside set_pos later as suggested by Kahsa)
 	s.set_pos(s.x, s.y)
 
@@ -120,32 +144,45 @@ fn (mut s Stack) init(parent Layout) {
 	}
 }
 
-fn (mut s Stack) set_all_sizes(parent Layout) {
-	// Only once for all children recursively find all the adjusted sizes
+fn (mut s Stack) init_size(parent Layout) {
+	parent_width, parent_height := parent.size()
+	// s.debug_show_sizes("decode before -> ")
 	if parent is Window {
-		s.set_adjusted_size(0, true, s.ui)
+		// Default: like stretch = strue
+		s.height = parent_height - s.margin.top - s.margin.right
+		s.width = parent_width - s.margin.left - s.margin.right
+	} else if s.stretch {
+		if s.direction == .row {
+			s.height = parent_height - s.margin.top - s.margin.right
+		} else {
+			s.width = parent_width - s.margin.left - s.margin.right
+		}
 	}
+}
 
-	s.init_size(parent)
-
-	// if s.direction == .column {
-	if s.height == 0 {
-		println('stack adjusted height')
-		s.height = s.adj_height
-	} else {
-		s.height -= s.margin.top + s.margin.bottom
-	}
-	// } else {
-	if s.width == 0 {
-		s.width = s.adj_width
-	} else {
-		s.width -= s.margin.left + s.margin.right
-	}
-	// println('stack $s.name() => size ($s.width, $s.height) cfg: ($s.cfg_width, $s.cfg_height) adj: ($s.adj_width, $s.adj_height) ')
-	s.debug_show_sizes('init -> ')
+fn (mut s Stack) set_children_sizes(parent Layout) {
+	$if debug_sizes ? {s.debug_show_sizes("BEGIN set_children_size ")}
 
 	//* size of children from *
-	// default values for widths and heights
+	// s.default_sizes()
+
+	// set children sizes
+	$if debug_sizes ? { println('s.widths: $s.widths s.heights: $s.heights')}
+	free_width, free_height := s.free_size()
+	for i, mut child in s.children {
+		w,h := s.set_child_size(child, i, free_width, free_height)
+		
+		child.propose_size(w, h)
+
+		if child is Stack {
+			child.set_children_sizes(s)
+		}
+	}
+	$if debug_sizes ? {s.debug_show_sizes("END set_children_size ")} 
+}
+
+// default values for s.widths and s.heights
+fn (mut s Stack) default_sizes() {
 	if s.direction == .row {
 		if s.heights.len == 0 {
 			s.heights = [f32(1)].repeat(s.children.len)
@@ -173,49 +210,227 @@ fn (mut s Stack) set_all_sizes(parent Layout) {
 			s.heights = [p].repeat(s.children.len)
 		}
 	}
-
-	// set children sizes
-	println('s.widths: $s.widths s.heights: $s.heights')
-	free_width, free_height := s.free_size()
-	for i, mut child in s.children {
-		mut w, mut h := child.size()
-		// TODO: replace set_width and set_height by with propose_size
-		if i < s.widths.len && s.widths[i] > 0 {
-			w = size_f32_to_int(s.widths[i])
-			println('widths[$i]=  $w <- ${s.widths[i]}')
-			w = relative_size_from_parent(w, free_width)
-			println('w[$i]=  $w')
-		}
-		if i < s.heights.len && s.heights[i] > 0 {
-			h = size_f32_to_int(s.heights[i])
-			println('heights[$i]= $h <- ${s.heights[i]}')
-			h = relative_size_from_parent(h, free_height)
-			println('h[$i]=  $h')
-		}
-		// It is then unchanged when 
-		child.propose_size(w, h)
-	}
-	//* end size of children *
 }
 
-/*
-The rules for internal decoding of size (no need for the user to know that) are:
-* size < 0 (get from relative parent size) =>
-*/
-fn (mut s Stack) init_size(parent Layout) {
-	parent_width, parent_height := parent.size()
-	// s.debug_show_sizes("decode before -> ")
-	if parent is Window {
-		// Default: like stretch = strue
-		s.height = parent_height - s.margin.top - s.margin.right
-		s.width = parent_width - s.margin.left - s.margin.right
-	} else if s.stretch {
-		if s.direction == .row {
-			s.height = parent_height - s.margin.top - s.margin.right
-		} else {
-			s.width = parent_width - s.margin.left - s.margin.right
+fn (mut s Stack) set_child_size(mut child Widget, i int, free_width int, free_height int) (int, int) {
+	// set initial child size
+	if child is Stack {
+		child.adjustable_size()
+	}
+	mut w, mut h := child.size()
+
+	// TODO: replace set_width and set_height by with propose_size
+	if i < s.widths.len && s.widths[i] > 0 {
+		w = size_f32_to_int(s.widths[i])
+		// println('widths[$i]=  $w <- ${s.widths[i]}')
+		w = relative_size_from_parent(w, free_width)
+		// println('w[$i]=  $w')
+	}
+	if i < s.heights.len && s.heights[i] > 0 {
+		h = size_f32_to_int(s.heights[i])
+		// println('heights[$i]= $h <- ${s.heights[i]}')
+		h = relative_size_from_parent(h, free_height)
+		// println('h[$i]=  $h')
+	}
+	return w, h
+}
+
+fn (mut s Stack) adjustable_size() {
+	if s.height == 0 {
+		$if debug_adjustable ? {
+			print('stack $s.name() ')
+			C.printf(' %p', s)
+			println(' adjusted height $s.height <- $s.adj_height')
+		}
+		s.height = s.adj_height
+	}
+	if s.width == 0 {
+		$if debug_decode ? {
+			print('stack $s.name() ')
+			C.printf(' %p', s)
+			println(' adjusted width $s.width <- $s.adj_width')
+		}
+		s.width = s.adj_width
+	}
+	// println('stack $s.name() => size ($s.width, $s.height) cfg: ($s.cfg_width, $s.cfg_height) adj: ($s.adj_width, $s.adj_height) ')
+	// s.debug_show_sizes('init -> ')
+}
+
+fn (mut s Stack) set_cache_sizes() {
+	// 
+	s.default_sizes()
+	//
+	len := s.children.len
+	mut c := &s.cache
+	// size preallocated
+	c.alloc_width, c.alloc_height = 0, 0
+	// fixed_<size>s and weight_<size>s can be cached in the Stack struct as private fields
+	// since once they are determined, they would never be updated
+	// above all, they would be used when resizing
+	c.fixed_widths, c.fixed_heights = [0].repeat(len), [0].repeat(len)
+	c.weight_widths, c.weight_heights = [0.].repeat(len), [0.].repeat(len) 
+	
+	for i, mut child in s.children {
+		// adjusted (natural size) child size
+		if child is Stack {
+			child.adjustable_size()
+		}
+		adj_child_width, adj_child_height := child.size()
+
+		// cw as child width with type f64 
+		cw := s.widths[i] or { 0 }
+		if cw > 1 { 
+			// fixed size ?
+			if cw == int(cw) {
+				c.fixed_widths[i] = int(cw)
+				c.alloc_width += c.fixed_widths[i]
+			}
+			// maybe consider later 200.6 as 200 as minimal size and .6 as weight
+		} else if cw > 0 {
+			// weighted size
+			c.weight_widths[i] = cw
+			// Internally, fixed_widths[i] is set to minimal fixed size
+			c.fixed_widths[i] = adj_child_width
+		} else if cw == 0 {
+			// width for Widget and adj_width for Layout
+			c.fixed_widths[i] = adj_child_width
+			// N.B.: Internally, weight_widths = 0 means that the sizes inherit from children
+		} else if cw == -1 {
+			// Internally, weight_widths = -1 means that the children can have their size updated from the parent
+			c.weight_widths[i] = -1.
+			// This is the initial size
+			c.fixed_widths[i] = adj_child_width
+		}
+		// ch as child height with type f64 
+		ch := s.heights[i] or { 0 }
+		if ch > 1 { 
+			// fixed size ?
+			if ch == int(ch) {
+				c.fixed_heights[i] = int(ch)
+				c.alloc_height += c.fixed_heights[i]
+			}
+			// maybe consider later 200.6 as 200 as minimal size and .6 as weight
+		} else if ch > 0 {
+			// weighted size
+			c.weight_heights[i] = ch
+			// Internally, fixed_heights[i] is set to minimal fixed size
+			c.fixed_heights[i] = adj_child_height
+		} else if ch == 0 {
+			// height for Widget and adj_height for Layout
+			c.fixed_heights[i] = adj_child_height
+			// N.B.: Internally, weight_heights = 0 means that the sizes inherit from children
+		} else if ch == -1 {
+			// Internally, weight_heights = -1 means that the children can have their size updated from the parent
+			c.weight_heights[i] = -1.
+			// This is the initial size
+			c.fixed_heights[i] = adj_child_height
+		}
+
+		// recursively do the same for Stack children
+		if child is Stack {
+			child.set_cache_sizes()
 		}
 	}
+}
+
+fn (s &Stack) alloc_children_sizes() ([]int, []int) {
+	mut mcw, mut mch := []int{}, []int{}
+	// free size without margin and spacing
+	// free_width, free_height := s.free_size()
+	c := &s.cache
+	
+	return mcw, mch
+}
+
+fn (mut s Stack) propose_size(w int, h int) (int, int) {
+	// if s.stretch {
+	// 	s.width = w
+	// 	if s.height == 0 {
+	// 		s.height = h
+	// 	}
+	// }
+	s.width, s.height = w - s.margin.left - s.margin.right, h - s.margin.top - s.margin.bottom
+	return s.width, s.height
+}
+
+fn (s &Stack) size() (int, int) {
+	mut w := s.width
+	mut h := s.height
+	// TODO: this has to disappear (not depending on adjusted_size)
+	// if s.width < s.adj_width {
+	// 	w = s.adj_width
+	// }
+	// if s.height < s.adj_height {
+	// 	h = s.adj_height
+	// }
+	w += s.margin.left + s.margin.right
+	h += s.margin.top + s.margin.bottom
+	return w, h
+}
+
+fn (s &Stack) free_size() (int, int) {
+	mut w := s.width
+	mut h := s.height
+	if s.direction == .row {
+		w -= s.total_spacing()
+	} else {
+		h -= s.total_spacing()
+	}
+	return w, h
+}
+
+fn (mut s Stack) set_adjusted_size(i int, force bool, ui &UI) {
+	mut h := 0
+	mut w := 0
+	for mut child in s.children {
+		mut child_width, mut child_height := 0, 0
+		if child is Stack {
+			if force || child.adj_width == 0 {
+				child.set_adjusted_size(i + 1, force, ui)
+			}
+			child_width, child_height = child.adj_width + child.margin.left + child.margin.right, 
+				child.adj_height + child.margin.top + child.margin.bottom
+		} else if child is Group {
+			if force || child.adj_width == 0 {
+				child.set_adjusted_size(i + 1, ui)
+			}
+			child_width, child_height = child.adj_width + child.margin_left + child.margin_right, 
+				child.adj_height + child.margin_top + child.margin_bottom
+		} else {
+			if child is Label {
+				child.set_ui(ui)
+			} else if child is Button {
+				child.set_ui(ui)
+			}
+			child_width, child_height = child.size()
+		}
+		if s.direction == .column {
+			h += child_height // height of vertical stack means adding children's height
+			if child_width > w { // width of vertical stack means greatest children's width
+				w = child_width
+			}
+		} else {
+			w += child_width // width of horizontal stack means adding children's width
+			if child_height > h { // height of horizontal stack means greatest children's height
+				h = child_height
+			}
+		}
+	}
+	// adding total spacing between children
+	if s.direction == .column {
+		h += s.total_spacing()
+	} else {
+		w += s.total_spacing()
+	}
+	s.adj_width = w
+	s.adj_height = h
+}
+
+fn (mut s Stack) set_pos(x int, y int) {
+	// could depend on anchor in the future 
+	// Default is anchor=.top_left here (and could be .top_right, .bottom_left, .bottom_right)
+	s.x = x + s.margin.left
+	s.y = y + s.margin.top
 }
 
 fn (mut s Stack) set_children_pos() {
@@ -296,100 +511,9 @@ fn (s &Stack) set_child_pos(mut child Widget, i int, x int, y int) {
 	}
 }
 
-fn (mut s Stack) set_adjusted_size(i int, force bool, ui &UI) {
-	mut h := 0
-	mut w := 0
-	for mut child in s.children {
-		mut child_width, mut child_height := 0, 0
-		if child is Stack {
-			if force || child.adj_width == 0 {
-				child.set_adjusted_size(i + 1, force, ui)
-			}
-			child_width, child_height = child.adj_width + child.margin.left + child.margin.right, 
-				child.adj_height + child.margin.top + child.margin.bottom
-		} else if child is Group {
-			if force || child.adj_width == 0 {
-				child.set_adjusted_size(i + 1, ui)
-			}
-			child_width, child_height = child.adj_width + child.margin_left + child.margin_right, 
-				child.adj_height + child.margin_top + child.margin_bottom
-		} else {
-			if child is Label {
-				child.set_ui(ui)
-			} else if child is Button {
-				child.set_ui(ui)
-			}
-			child_width, child_height = child.size()
-		}
-		if s.direction == .column {
-			h += child_height // height of vertical stack means adding children's height
-			if child_width > w { // width of vertical stack means greatest children's width
-				w = child_width
-			}
-		} else {
-			w += child_width // width of horizontal stack means adding children's width
-			if child_height > h { // height of horizontal stack means greatest children's height
-				h = child_height
-			}
-		}
-	}
-	// adding total spacing between children
-	if s.direction == .column {
-		h += s.total_spacing()
-	} else {
-		w += s.total_spacing()
-	}
-	s.adj_width = w
-	s.adj_height = h
-}
-
-fn (mut s Stack) set_pos(x int, y int) {
-	// could depend on anchor in the future 
-	// Default is anchor=.top_left here (and could be .top_right, .bottom_left, .bottom_right)
-	s.x = x + s.margin.left
-	s.y = y + s.margin.top
-}
-
 fn (s &Stack) get_subscriber() &eventbus.Subscriber {
 	parent := s.parent
 	return parent.get_subscriber()
-}
-
-fn (mut s Stack) propose_size(w int, h int) (int, int) {
-	// if s.stretch {
-	// 	s.width = w
-	// 	if s.height == 0 {
-	// 		s.height = h
-	// 	}
-	// }
-	s.width, s.height = w - s.margin.left - s.margin.right, h - s.margin.top - s.margin.bottom
-	return s.width, s.height
-}
-
-fn (s &Stack) size() (int, int) {
-	mut w := s.width
-	mut h := s.height
-	// TODO: this has to disappear (not depending on adjusted_size)
-	// if s.width < s.adj_width {
-	// 	w = s.adj_width
-	// }
-	// if s.height < s.adj_height {
-	// 	h = s.adj_height
-	// }
-	w += s.margin.left + s.margin.right
-	h += s.margin.top + s.margin.bottom
-	return w, h
-}
-
-fn (s &Stack) free_size() (int, int) {
-	mut w := s.width
-	mut h := s.height
-	if s.direction == .row {
-		w -= s.total_spacing()
-	} else {
-		h -= s.total_spacing()
-	}
-	return w, h
 }
 
 fn (mut s Stack) draw() {
@@ -397,18 +521,20 @@ fn (mut s Stack) draw() {
 		child.draw()
 	}
 	// DEBUG MODE: Uncomment to display the bounding boxes
-	// s.draw_bb()
+	$if debug_bb ? {
+		s.draw_bb()
+	}
 }
 
 fn (s &Stack) total_spacing() int {
 	mut total_spacing := 0
-	println('len $s.children.len $s.spacing')
+	// println('len $s.children.len $s.spacing')
 	if s.spacing.len > 0 && s.children.len > 1 {
 		for i in 0 .. (s.children.len - 1) {
 			total_spacing += s.spacing[i]
 		}
 	}
-	println('len $total_spacing')
+	// println('len $total_spacing')
 	return total_spacing
 }
 
@@ -479,4 +605,80 @@ fn (s &Stack) get_horizontal_alignment(i int) HorizontalAlignment {
 		align = .right
 	}
 	return align
+}
+
+fn (s &Stack) set_child_pos_aligned(mut child Widget, i int, x int, y int) {
+	child_width, child_height := child.size()
+	horizontal_alignment, vertical_alignment := s.get_alignments(i)
+	// set x_offset
+	container_width := s.width
+	mut x_offset := 0
+	match horizontal_alignment {
+		.left {
+			x_offset = 0
+		}
+		.center {
+			if container_width > child_width {
+				x_offset = (container_width - child_width) / 2
+			} else {
+				x_offset = 0
+			}
+		}
+		.right {
+			if container_width > child_width {
+				x_offset = (container_width - child_width)
+			} else {
+				x_offset = 0
+			}
+		}
+	}
+	// set y_offset
+	container_height := s.height
+	mut y_offset := 0
+	match vertical_alignment {
+		.top {
+			y_offset = 0
+		}
+		.center {
+			if container_height > child_height {
+				y_offset = (container_height - child_height) / 2
+			} else {
+				y_offset = 0
+			}
+		}
+		.bottom {
+			if container_height > child_height {
+				y_offset = container_height - child_height
+			} else {
+				y_offset = 0
+			}
+		}
+	}
+	child.set_pos(x + x_offset, y + y_offset)
+}
+
+fn (s &Stack) get_alignments(i int) (HorizontalAlignment, VerticalAlignment)  {
+	mut hor_align := s.horizontal_alignment
+	mut ver_align := s.vertical_alignment
+	if i in s.alignments.center {
+		hor_align, ver_align = .center, .center
+	} else if i in s.alignments.left_top {
+		hor_align, ver_align = .left, .top
+	} else if i in s.alignments.top {
+		hor_align, ver_align = .center, .top
+	} else if i in s.alignments.right_top  {
+		hor_align, ver_align = .right, .top
+	} else if i in s.alignments.right {
+		hor_align, ver_align = .right, .center
+	} else if i in s.alignments.right_bottom {
+		hor_align, ver_align = .right, .bottom
+	} else if i in s.alignments.bottom {
+		hor_align, ver_align = .center, .bottom
+	} else if i in s.alignments.left_bottom {
+		hor_align, ver_align = .left, .bottom
+	} else if i in s.alignments.left {
+		hor_align, ver_align = .left, .center
+	}
+
+	return hor_align, ver_align
 }

--- a/stack.v
+++ b/stack.v
@@ -119,17 +119,14 @@ fn (mut s Stack) init(parent Layout) {
 		}
 		// 3) set all the sizes (could be updated possibly for resizing)
 		$if devel  ? {
-			s.set_children_sizes_tmp()
+			s.set_children_sizes()
 		} $else {
-			s.set_children_sizes(parent)
+			s.set_children_sizes_old(parent)
 		}
 		
 	} else if parent is Stack {
 		s.root = parent.root
 	}
-
-	// 2) set all the sizes
-		// s.set_children_sizes(parent)
 
 	// All sizes have to be set before positionning widgets
 	// Set the position of this stack (anchor could possibly be defined inside set_pos later as suggested by Kahsa)
@@ -165,8 +162,8 @@ fn (mut s Stack) init_size(parent Layout) {
 	}
 }
 
-fn (mut s Stack) set_children_sizes(parent Layout) {
-	$if debug_sizes ? {s.debug_show_sizes("BEGIN set_children_size ")}
+fn (mut s Stack) set_children_sizes_old(parent Layout) {
+	$if debug_sizes ? {s.debug_show_sizes("BEGIN set_children_size_old ")}
 
 	//* size of children from *
 
@@ -179,10 +176,10 @@ fn (mut s Stack) set_children_sizes(parent Layout) {
 		child.propose_size(w, h)
 
 		if child is Stack {
-			child.set_children_sizes(s)
+			child.set_children_sizes_old(s)
 		}
 	}
-	$if debug_sizes ? {s.debug_show_sizes("END set_children_size ")} 
+	$if debug_sizes ? {s.debug_show_sizes("END set_children_size_old ")} 
 }
 
 // default values for s.widths and s.heights
@@ -471,8 +468,8 @@ fn (s &Stack) children_sizes() ([]int, []int) {
 }
 
 
-fn (mut s Stack) set_children_sizes_tmp() {
-	$if debug_sizes ? {s.debug_show_sizes("BEGIN set_children_size_tmp ")}
+fn (mut s Stack) set_children_sizes() {
+	$if debug_sizes ? {s.debug_show_sizes("BEGIN set_children_size ")}
 
 	//* size of children from *
 	c := &s.cache
@@ -487,10 +484,10 @@ fn (mut s Stack) set_children_sizes_tmp() {
 			w, h= widths[i], heights[i]
 		} else {
 			// For widget, only when proposed mode accepted 
-			if c.weight_widths[i] < 0 {
+			if s.widths[i] == ui.stretch || c.weight_widths[i] < 0 {
 				w = widths[i]
 			}
-			if c.weight_heights[i] < 0 {
+			if s.heights[i] == ui.stretch || c.weight_heights[i] < 0 {
 				h = heights[i]
 			}
 		}
@@ -498,7 +495,7 @@ fn (mut s Stack) set_children_sizes_tmp() {
 		child.propose_size(w, h)
 
 		if child is Stack {
-			child.set_children_sizes_tmp()
+			child.set_children_sizes()
 		}
 	}
 	$if debug_sizes ? {s.debug_show_sizes("END set_children_size ")} 

--- a/textbox.v
+++ b/textbox.v
@@ -29,7 +29,9 @@ const (
 
 type KeyDownFn = fn (voidptr, voidptr, u32)
 
-type KeyUpFn = fn (voidptr, voidptr, u32)
+type CharFn = fn (voidptr, voidptr, u32)
+
+// type KeyUpFn = fn (voidptr, voidptr, u32)
 
 type TextBoxChangeFn = fn (string, voidptr)
 
@@ -61,7 +63,8 @@ pub mut:
 	read_only          bool
 	borderless         bool
 	on_key_down        KeyDownFn = KeyDownFn(0)
-	on_key_up          KeyUpFn   = KeyUpFn(0)
+	on_char            CharFn   = CharFn(0)
+	// on_key_up          KeyUpFn   = KeyUpFn(0)
 	dragging           bool
 	sel_direction      SelectionDirection
 	border_accentuated bool
@@ -99,7 +102,8 @@ pub struct TextBoxConfig {
 	// is_error bool
 	borderless         bool
 	on_key_down        KeyDownFn
-	on_key_up          KeyUpFn
+	on_char            CharFn
+	// on_key_up          KeyUpFn
 	on_change          voidptr
 	on_enter           voidptr
 	border_accentuated bool
@@ -113,7 +117,8 @@ fn (mut tb TextBox) init(parent Layout) {
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_click, tb_click, tb)
 	subscriber.subscribe_method(events.on_key_down, tb_key_down, tb)
-	subscriber.subscribe_method(events.on_key_up, tb_key_up, tb)
+	subscriber.subscribe_method(events.on_char, tb_char, tb)
+	// subscriber.subscribe_method(events.on_key_up, tb_key_up, tb)
 	subscriber.subscribe_method(events.on_mouse_move, tb_mouse_move, tb)
 }
 
@@ -131,7 +136,8 @@ pub fn textbox(c TextBoxConfig) &TextBox {
 		read_only: c.read_only
 		borderless: c.borderless
 		on_key_down: c.on_key_down
-		on_key_up: c.on_key_up
+		on_char: c.on_char
+		// on_key_up: c.on_key_up
 		on_change: c.on_change
 		on_enter: c.on_enter
 		border_accentuated: c.border_accentuated
@@ -253,12 +259,23 @@ fn (mut tb TextBox) draw() {
 	}
 }
 
-fn tb_key_up(mut tb TextBox, e &KeyEvent, window &Window) {
-	if !tb.is_focused {
+// fn tb_key_up(mut tb TextBox, e &KeyEvent, window &Window) {
+// 	println("hvhvh")
+// 	if !tb.is_focused {
+// 		return
+// 	}
+// 	if tb.on_key_up != voidptr(0) {
+// 		tb.on_key_up(window.state, tb, e.codepoint)
+// 	}
+// }
+
+fn tb_char(mut tb TextBox, e &KeyEvent, window &Window) {
+	//  println("tb_char")
+	 if !tb.is_focused {
 		return
 	}
-	if tb.on_key_up != voidptr(0) {
-		tb.on_key_up(window.state, tb, e.codepoint)
+	if tb.on_char != voidptr(0) {
+		tb.on_char(window.state, tb, e.codepoint)
 	}
 }
 

--- a/textbox.v
+++ b/textbox.v
@@ -37,7 +37,7 @@ type TextBoxChangeFn = fn (string, voidptr)
 
 type TextBoxEnterFn = fn (string, voidptr)
 
-[ref_only]
+[heap]
 pub struct TextBox {
 pub mut:
 	height     int

--- a/textbox.v
+++ b/textbox.v
@@ -49,21 +49,21 @@ pub mut:
 	// gg &gg.GG
 	ui &UI
 	// text               string
-	text               &string = voidptr(0)
-	max_len            int
-	is_multi           bool
-	placeholder        string
-	placeholder_bind   &string = voidptr(0)
-	cursor_pos         int
-	is_numeric         bool
-	is_password        bool
-	sel_start          int
-	sel_end            int
-	last_x             int
-	read_only          bool
-	borderless         bool
-	on_key_down        KeyDownFn = KeyDownFn(0)
-	on_char            CharFn   = CharFn(0)
+	text             &string = voidptr(0)
+	max_len          int
+	is_multi         bool
+	placeholder      string
+	placeholder_bind &string = voidptr(0)
+	cursor_pos       int
+	is_numeric       bool
+	is_password      bool
+	sel_start        int
+	sel_end          int
+	last_x           int
+	read_only        bool
+	borderless       bool
+	on_key_down      KeyDownFn = KeyDownFn(0)
+	on_char          CharFn    = CharFn(0)
 	// on_key_up          KeyUpFn   = KeyUpFn(0)
 	dragging           bool
 	sel_direction      SelectionDirection
@@ -100,9 +100,9 @@ pub struct TextBoxConfig {
 	is_error         &bool   = voidptr(0)
 	is_focused       bool
 	// is_error bool
-	borderless         bool
-	on_key_down        KeyDownFn
-	on_char            CharFn
+	borderless  bool
+	on_key_down KeyDownFn
+	on_char     CharFn
 	// on_key_up          KeyUpFn
 	on_change          voidptr
 	on_enter           voidptr
@@ -271,7 +271,7 @@ fn (mut tb TextBox) draw() {
 
 fn tb_char(mut tb TextBox, e &KeyEvent, window &Window) {
 	//  println("tb_char")
-	 if !tb.is_focused {
+	if !tb.is_focused {
 		return
 	}
 	if tb.on_char != voidptr(0) {

--- a/transition.v
+++ b/transition.v
@@ -8,6 +8,8 @@ import time
 pub struct Transition {
 mut:
 	// pub:
+	x                int
+	y                int
 	last_draw_time   i64
 	started_time     i64
 	duration         i64

--- a/ui.v
+++ b/ui.v
@@ -54,6 +54,8 @@ pub enum HorizontalAlignment {
 }
 
 pub interface Widget {
+	x int
+	y int
 	init(Layout)
 	// key_down(KeyEvent)
 	draw()

--- a/ui_extra_align.v
+++ b/ui_extra_align.v
@@ -14,6 +14,7 @@ pub struct VerticalAlignments {
 
 // Anticipating replacement of VerticalAlignments
 pub struct Alignments {
+	center       []int
 	left_top     []int
 	top          []int
 	right_top    []int

--- a/ui_extra_debug.v
+++ b/ui_extra_debug.v
@@ -17,23 +17,23 @@ fn (s &Stack) draw_bb() {
 // Debug function
 fn (s &Stack) debug_show_cache(depth int, txt string) {
 	if depth == 0 {
-		println("Show cache =>")
+		println('Show cache =>')
 	}
-	tab := "  ".repeat(depth)
-	println('$tab ($depth) Stack $s.name() with ${s.children.len} children: (${s.cache.fixed_widths.len}, ${s.cache.fixed_heights.len})')
+	tab := '  '.repeat(depth)
+	println('$tab ($depth) Stack $s.name() with $s.children.len children: ($s.cache.fixed_widths.len, $s.cache.fixed_heights.len)')
 	free_width, free_height := s.free_size()
-	println("$tab   free size: ($free_width, $free_height)")
+	println('$tab   free size: ($free_width, $free_height)')
 	widths, heights := s.children_sizes()
 	println(txt)
 	for i, child in s.children {
 		if child is Stack {
-			 mut tmp := "$tab      ($depth-$i) $child.name() : (${s.cache.fixed_widths[i]},${s.cache.fixed_heights[i]}) and (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})"
-			 tmp +=     "\n$tab      weight: (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})"
-			 tmp +=     "\n$tab      size: (${widths[i]},${heights[i]})"
-			child.debug_show_cache(depth+1, tmp)
+			mut tmp := '$tab      ($depth-$i) $child.name() : (${s.cache.fixed_widths[i]},${s.cache.fixed_heights[i]}) and (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})'
+			tmp += '\n$tab      weight: (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})'
+			tmp += '\n$tab      size: (${widths[i]},${heights[i]})'
+			child.debug_show_cache(depth + 1, tmp)
 		} else {
 			w, h := child.size()
-			println("$tab      ($depth-$i) Widget $child.name() size ($w, $h) (${s.cache.fixed_widths[i]},${s.cache.fixed_heights[i]}) and (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})")
+			println('$tab      ($depth-$i) Widget $child.name() size ($w, $h) (${s.cache.fixed_widths[i]},${s.cache.fixed_heights[i]}) and (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})')
 		}
 	}
 }

--- a/ui_extra_debug.v
+++ b/ui_extra_debug.v
@@ -15,6 +15,24 @@ fn (s &Stack) draw_bb() {
 }
 
 // Debug function
+fn (s &Stack) debug_show_cache(depth int) {
+	if depth == 0 {
+		println("Show cache =>")
+	}
+	tab := "  ".repeat(depth)
+	println('$tab Stack $s.name() with ${s.children.len} children:')
+	println('$tab   (${s.cache.fixed_widths.len}, ${s.cache.fixed_heights.len})')
+	for i, child in s.children {
+		if child is Stack {
+			println("$tab   $i) fixed: (${s.cache.fixed_widths[i]},${s.cache.fixed_heights[i]})")
+			println("$tab   $i) weight: (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})")
+			child.debug_show_cache(depth+1)
+		} else {
+			println("$tab  $i) Widget $child.name()")
+		}
+	}
+}
+
 fn (s &Stack) debug_show_size(t string) {
 	print('${t}size of Stack $s.name()')
 	C.printf(' %p: ', s)
@@ -28,13 +46,17 @@ fn (s &Stack) debug_show_sizes(t string) {
 	C.printf(' %p', s)
 	println(' => size ($sw, $sh), ($s.width, $s.height)  adj: ($s.adj_width, $s.adj_height) spacing: $s.spacing')
 	if parent is Stack {
-		println('	parent: $parent.name() => size ($parent.width, $parent.height)  adj: ($parent.adj_width, $parent.adj_height) spacing: $parent.spacing')
+		print('	parent: $parent.name() ')
+		C.printf(' %p', parent)
+		println('=> size ($parent.width, $parent.height)  adj: ($parent.adj_width, $parent.adj_height) spacing: $parent.spacing')
 	} else if parent is Window {
 		println('	parent: Window => size ($parent.width, $parent.height)  adj: ($parent.adj_width, $parent.adj_height) ')
 	}
 	for i, child in s.children {
 		w, h := child.size()
-		println('		$i) $child.name() size => $w, $h')
+		print('		$i) $child.name()')
+		C.printf(' %p', child)
+		println(' size => $w, $h')
 	}
 }
 

--- a/ui_extra_debug.v
+++ b/ui_extra_debug.v
@@ -15,20 +15,25 @@ fn (s &Stack) draw_bb() {
 }
 
 // Debug function
-fn (s &Stack) debug_show_cache(depth int) {
+fn (s &Stack) debug_show_cache(depth int, txt string) {
 	if depth == 0 {
 		println("Show cache =>")
 	}
 	tab := "  ".repeat(depth)
-	println('$tab Stack $s.name() with ${s.children.len} children:')
-	println('$tab   (${s.cache.fixed_widths.len}, ${s.cache.fixed_heights.len})')
+	println('$tab ($depth) Stack $s.name() with ${s.children.len} children: (${s.cache.fixed_widths.len}, ${s.cache.fixed_heights.len})')
+	free_width, free_height := s.free_size()
+	println("$tab   free size: ($free_width, $free_height)")
+	widths, heights := s.children_sizes()
+	println(txt)
 	for i, child in s.children {
 		if child is Stack {
-			println("$tab   $i) fixed: (${s.cache.fixed_widths[i]},${s.cache.fixed_heights[i]})")
-			println("$tab   $i) weight: (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})")
-			child.debug_show_cache(depth+1)
+			 mut tmp := "$tab      ($depth-$i) $child.name() : (${s.cache.fixed_widths[i]},${s.cache.fixed_heights[i]}) and (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})"
+			 tmp +=     "\n$tab      weight: (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})"
+			 tmp +=     "\n$tab      size: (${widths[i]},${heights[i]})"
+			child.debug_show_cache(depth+1, tmp)
 		} else {
-			println("$tab  $i) Widget $child.name()")
+			w, h := child.size()
+			println("$tab      ($depth-$i) Widget $child.name() size ($w, $h) (${s.cache.fixed_widths[i]},${s.cache.fixed_heights[i]}) and (${s.cache.weight_widths[i]},${s.cache.weight_heights[i]})")
 		}
 	}
 }

--- a/ui_extra_size.v
+++ b/ui_extra_size.v
@@ -1,7 +1,7 @@
 module ui
 
 pub const (
-	stretch = -100
+	stretch = -100.
 	compact = 0. // from parent
 )
 

--- a/ui_extra_size.v
+++ b/ui_extra_size.v
@@ -1,7 +1,8 @@
 module ui
 
 pub const (
-	compact = -1. // from parent
+	stretch = -100
+	compact = 0. // from parent
 )
 
 pub type Size = []f64 | f64
@@ -70,8 +71,12 @@ struct CachedSizes {
 mut:
 	fixed_widths   []int
 	fixed_heights  []int
+	fixed_width    int
+	fixed_height   int
+	min_width      int
+	min_height     int
 	weight_widths  []f64
+	width_mass     f64
 	weight_heights []f64
-	alloc_width    int
-	alloc_height   int
+	height_mass    f64
 }

--- a/ui_extra_size.v
+++ b/ui_extra_size.v
@@ -65,3 +65,13 @@ fn is_children_have_widget(children []Widget) bool {
 	tmp := children.filter(!(it is Stack || it is Group))
 	return tmp.len > 0
 }
+
+struct CachedSizes {
+mut:
+	fixed_widths   []int
+	fixed_heights  []int
+	weight_widths  []f64
+	weight_heights []f64
+	alloc_width    int
+	alloc_height   int
+}

--- a/ui_extra_size.v
+++ b/ui_extra_size.v
@@ -1,5 +1,9 @@
 module ui
 
+pub const (
+	compact = -1. // from parent
+)
+
 pub type Size = []f64 | f64
 
 fn (size Size) as_f32_array(len int) []f32 {
@@ -55,4 +59,9 @@ fn (i Spacing) as_int_array(len int) []int {
 	} else {
 		[]int{}
 	}
+}
+
+fn is_children_have_widget(children []Widget) bool {
+	tmp := children.filter(!(it is Stack || it is Group))
+	return tmp.len > 0
 }

--- a/webview/webview.v
+++ b/webview/webview.v
@@ -3,7 +3,7 @@
 module webview
 
 // import ui
-[ref_only]
+[heap]
 struct WebView {
 	// widget ui.Widget
 	url string

--- a/window.v
+++ b/window.v
@@ -74,6 +74,7 @@ pub:
 	on_mouse_down         ClickFn
 	on_mouse_up           ClickFn
 	on_key_down           KeyFn
+	on_char               KeyFn
 	on_scroll             ScrollFn
 	on_resize             ResizeFn
 	on_mouse_move         MouseMoveFn
@@ -189,6 +190,7 @@ pub fn window(cfg WindowConfig, children []Widget) &Window {
 		children: children
 		click_fn: cfg.on_click
 		key_down_fn: cfg.on_key_down
+		char_fn: cfg.on_char
 		scroll_fn: cfg.on_scroll
 		mouse_move_fn: cfg.on_mouse_move
 		mouse_down_fn: cfg.on_mouse_down
@@ -490,6 +492,11 @@ fn window_char(event sapp.Event, ui &UI) {
 		window.key_down_fn(e, window.state)
 	}
 	window.eventbus.publish(events.on_key_down, window, e)
+	if window.char_fn != voidptr(0) {
+		window.char_fn(e, window.state)
+	}
+	// window.eventbus.publish(events.on_char, window, e)
+	window.eventbus.publish(events.on_char, window, e)
 	/*
 	for child in window.children {
 		is_focused := child.is_focused()

--- a/window.v
+++ b/window.v
@@ -23,7 +23,7 @@ pub type MouseMoveFn = fn (e MouseMoveEvent, window &Window)
 
 pub type ResizeFn = fn (w int, h int, window &Window)
 
-[ref_only]
+[heap]
 pub struct Window {
 pub mut:
 	// pub:


### PR DESCRIPTION
* This PR fixes the issue introduced with propose_size for widgets. The default is now again to have the children at their initial size when children are not all layouts.
* Examples have also be updated to use the design with widths, heights and alignements. 