### PR TITLE
Add iconified fn

### DIFF
--- a/textbox.v
+++ b/textbox.v
@@ -109,7 +109,7 @@ pub struct TextBoxConfig {
 	border_accentuated bool
 }
 
-fn (mut tb TextBox) init(parent Layout) {
+pub fn (mut tb TextBox) init(parent Layout) {
 	tb.parent = parent
 	ui := parent.get_ui()
 	tb.ui = ui
@@ -182,7 +182,7 @@ fn (mut tb TextBox) propose_size(w int, h int) (int, int) {
 	return tb.width, tb.height
 }
 
-fn (mut tb TextBox) draw() {
+pub fn (mut tb TextBox) draw() {
 	text := *(tb.text)
 	mut placeholder := tb.placeholder
 	if tb.placeholder_bind != 0 {

--- a/textbox.v
+++ b/textbox.v
@@ -109,7 +109,7 @@ pub struct TextBoxConfig {
 	border_accentuated bool
 }
 
-pub fn (mut tb TextBox) init(parent Layout) {
+fn (mut tb TextBox) init(parent Layout) {
 	tb.parent = parent
 	ui := parent.get_ui()
 	tb.ui = ui
@@ -182,7 +182,7 @@ fn (mut tb TextBox) propose_size(w int, h int) (int, int) {
 	return tb.width, tb.height
 }
 
-pub fn (mut tb TextBox) draw() {
+fn (mut tb TextBox) draw() {
 	text := *(tb.text)
 	mut placeholder := tb.placeholder
 	if tb.placeholder_bind != 0 {

--- a/window.v
+++ b/window.v
@@ -59,7 +59,8 @@ pub mut:
 	char_fn       KeyFn
 	eventbus      &eventbus.EventBus = eventbus.new()
 	// resizable has limitation https://github.com/vlang/ui/issues/231
-	resizable bool
+	resizable  bool
+	fullscreen bool
 	// adjusted size generally depending on children
 	adj_width  int
 	adj_height int

--- a/window.v
+++ b/window.v
@@ -23,6 +23,10 @@ pub type MouseMoveFn = fn (e MouseMoveEvent, window &Window)
 
 pub type ResizeFn = fn (w int, h int, window &Window)
 
+pub type IconifiedFn = fn (state voidptr, window &Window)
+
+pub type RestoredFn = fn (state voidptr, window &Window)
+
 [heap]
 pub struct Window {
 pub mut:
@@ -43,17 +47,19 @@ pub mut:
 	width         int
 	height        int
 	bg_color      gx.Color
+	resize_fn     ResizeFn
+	iconified_fn  IconifiedFn
+	restored_fn   RestoredFn
 	click_fn      ClickFn
 	mouse_down_fn ClickFn
 	mouse_up_fn   ClickFn
+	mouse_move_fn MouseMoveFn
 	scroll_fn     ScrollFn
-	resize_fn     ResizeFn
 	key_down_fn   KeyFn
 	char_fn       KeyFn
-	mouse_move_fn MouseMoveFn
 	eventbus      &eventbus.EventBus = eventbus.new()
 	// resizable has limitation https://github.com/vlang/ui/issues/231
-	resizable bool // currently only for events.on_resized not modify children
+	resizable bool
 	// adjusted size generally depending on children
 	adj_width  int
 	adj_height int
@@ -68,17 +74,19 @@ pub:
 	title                 string
 	always_on_top         bool
 	state                 voidptr
+	children              []Widget
 	draw_fn               DrawFn
-	bg_color              gx.Color = ui.default_window_color
+	on_resize             ResizeFn
+	on_iconified          IconifiedFn
+	on_restored           RestoredFn
 	on_click              ClickFn
 	on_mouse_down         ClickFn
 	on_mouse_up           ClickFn
+	on_mouse_move         MouseMoveFn
 	on_key_down           KeyFn
 	on_char               KeyFn
 	on_scroll             ScrollFn
-	on_resize             ResizeFn
-	on_mouse_move         MouseMoveFn
-	children              []Widget
+	bg_color              gx.Color = ui.default_window_color
 	font_path             string
 	custom_bold_font_path string
 	native_rendering      bool
@@ -141,8 +149,14 @@ fn on_event(e &sapp.Event, mut window Window) {
 			// println('mod=$e.modifiers $e.num_touches $e.key_repeat $e.mouse_button')
 			window_mouse_move(e, window.ui)
 		}
-		.resized, .restored, .resumed {
+		.resized, .resumed {
 			window_resize(e, window.ui)
+		}
+		.iconified {
+			window_iconified(e, window.ui)
+		}
+		.restored {
+			window_restored(e, window.ui)
 		}
 		else {}
 	}
@@ -197,6 +211,8 @@ pub fn window(cfg WindowConfig, children []Widget) &Window {
 		mouse_up_fn: cfg.on_mouse_up
 		resizable: cfg.resizable
 		resize_fn: cfg.on_resize
+		iconified_fn: cfg.on_iconified
+		restored_fn: cfg.on_restored
 	}
 	gcontext := gg.new_context(
 		width: cfg.width
@@ -339,6 +355,20 @@ fn window_resize(event sapp.Event, ui &UI) {
 		if child is Stack {
 			child.resize(w, h)
 		}
+	}
+}
+
+fn window_iconified(event sapp.Event, ui &UI) {
+	window := ui.window
+	if window.iconified_fn != voidptr(0) {
+		window.iconified_fn(window.state, window)
+	}
+}
+
+fn window_restored(event sapp.Event, ui &UI) {
+	window := ui.window
+	if window.restored_fn != voidptr(0) {
+		window.restored_fn(window.state, window)
 	}
 }
 


### PR DESCRIPTION
Added `Window.iconified_fn` and `Window.restored_fn` fields.
Just tested on Linux not on Windows.
See if #296 is fixed by this RP.