### PR TITLE
add a note on ChromeOS dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ On some Linux distros you also need a few development dependencies:
 - Debian/Ubuntu: `sudo apt install libxi-dev libxcursor-dev mesa-common-dev`
 - Fedora: `sudo dnf install libXi-devel libXcursor-devel mesa-libGL-devel`
 
+On ChromeOS Linux/Crostini, install the Debian dependencies listed above followed by this:
+- `sudo apt install freeglut3-dev` ([see details](https://github.com/vlang/ui/issues/316))
+
 ### License
 
 V UI is licensed under GPL3. A commercial license will be available.


### PR DESCRIPTION
This is a follow-up to [issue 316](https://github.com/vlang/ui/issues/316) which proposes a solution for developing with v/ui on ChromeOS.