### PR TITLE
readme: add chrome os dependency libssl-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ On some Linux distros you also need a few development dependencies:
 - Fedora: `sudo dnf install libXi-devel libXcursor-devel mesa-libGL-devel`
 
 On ChromeOS Linux/Crostini, install the Debian dependencies listed above followed by this:
-- `sudo apt install freeglut3-dev` ([see details](https://github.com/vlang/ui/issues/316))
+- `sudo apt install libssl-dev freeglut3-dev` ([see details](https://github.com/vlang/ui/issues/316))
 
 ### License
 


### PR DESCRIPTION
Ran into this error on a fresh linux install in chrome os:
```
$ v install ui
cannot compile `/usr/local/share/v/cmd/tools/vpm.v`: 
builder error: 'openssl/rand.h' not found
```

The missing header can be installed through `libssl-dev` package. I'm not sure if it is preinstalled on regular debian, but the chrome os flavour does not come with it.