### PR TITLE
make WindowSizeType public

### DIFF
--- a/ui_extra_size.v
+++ b/ui_extra_size.v
@@ -5,7 +5,7 @@ pub const (
 	compact = 0. // from parent
 )
 
-enum WindowSizeType {
+pub enum WindowSizeType {
 	normal_size
 	resizable
 	max_size


### PR DESCRIPTION
Enums used outside of modules should be public. And this is required to fix below error

https://github.com/vlang/v/pull/9788/checks?check_run_id=2378437285#step:16:1
