### PR TITLE
fix for vlang/v PR #10033

### DIFF
--- a/listbox.v
+++ b/listbox.v
@@ -129,7 +129,7 @@ fn (mut lb ListBox) append_item(id string, text string, draw_to int) {
 		y: lb.item_height * lb.items.len
 		id: id
 		text: text
-		list: lb
+		list: unsafe { lb }
 		draw_text: text[0..draw_to]
 	}
 }

--- a/stack.v
+++ b/stack.v
@@ -132,8 +132,8 @@ fn (mut s Stack) init(parent Layout) {
 	}
 
 	if parent is Window {
-		ui.window = parent
-		mut window := parent
+		ui.window = unsafe { parent }
+		mut window := unsafe { parent }
 		window.root_layout = s
 		window.update_layout() // i.e s.update_all_children_recursively(parent)
 	}

--- a/transition.v
+++ b/transition.v
@@ -57,7 +57,7 @@ pub fn transition(c TransitionConfig) &Transition {
 }
 
 pub fn (mut t Transition) set_value(animated_value &int) {
-	t.animated_value = animated_value
+	t.animated_value = unsafe { animated_value }
 	t.start_value = *animated_value
 	t.target_value = *animated_value
 	t.last_draw_target = *animated_value


### PR DESCRIPTION
This adds some `unsafe` wrappers to allow compilation after vlang/v PR [10033](https://github.com/vlang/v/pull/10033) is merged.