### PR TITLE
use C string explicitely

### DIFF
--- a/ui_extra_debug.v
+++ b/ui_extra_debug.v
@@ -67,7 +67,7 @@ fn (s &Stack) debug_show_cache(depth int, txt string) {
 
 fn (s &Stack) debug_show_size(t string) {
 	print('${t}size of Stack ${typeof(s).name}')
-	C.printf(' %p: ', s)
+	C.printf(c' %p: ', s)
 	println(' ($s.width, $s.height)')
 }
 
@@ -75,11 +75,11 @@ fn (s &Stack) debug_show_sizes(t string) {
 	parent := s.parent
 	sw, sh := s.size()
 	print('${t}Stack ${typeof(s).name}')
-	C.printf(' %p', s)
+	C.printf(c' %p', s)
 	println(' => size ($sw, $sh), ($s.width, $s.height)  adj: ($s.adj_width, $s.adj_height) spacing: $s.spacings')
 	if mut parent is Stack {
 		// print('	parent: $${typeof(parent).name} ')
-		C.printf(' %p', parent)
+		C.printf(c' %p', parent)
 		println('=> size ($parent.width, $parent.height)  adj: ($parent.adj_width, $parent.adj_height) spacing: $parent.spacings')
 	} else if parent is Window {
 		println('	parent: Window => size ($parent.width, $parent.height)  orig: ($parent.orig_width, $parent.orig_height) ')
@@ -87,7 +87,7 @@ fn (s &Stack) debug_show_sizes(t string) {
 	for i, mut child in s.children {
 		w, h := child.size()
 		print('		$i) $child.type_name()')
-		C.printf(' %p', child)
+		C.printf(c' %p', child)
 		println(' size => $w, $h')
 	}
 }

--- a/window.v
+++ b/window.v
@@ -310,7 +310,7 @@ pub fn window(cfg WindowConfig, children []Widget) &Window {
 		// size: int(m / cfg.lines)
 	}
 
-	// C.printf('window() state =%p \n', cfg.state)
+	// C.printf(c'window() state =%p \n', cfg.state)
 	mut window := &Window{
 		state: cfg.state
 		draw_fn: cfg.draw_fn
@@ -686,7 +686,7 @@ fn window_click(event gg.Event, ui &UI) {
 fn window_key_down(event gg.Event, ui &UI) {
 	// println('keydown char=$event.char_code')
 	mut window := ui.window
-	// C.printf('g child=%p\n', child)
+	// C.printf(c'g child=%p\n', child)
 	e := KeyEvent{
 		key: Key(event.key_code)
 		mods: KeyMod(event.modifiers)


### PR DESCRIPTION
This will be required once automatic string to C string conversation is removed.
See https://github.com/vlang/v/pull/10140
This isn't necessary for this PR, but will produce warning once it is merged.