### PR TITLE
Fix Dropdown, MouseMoveEvent, and Button

### DIFF
--- a/button.v
+++ b/button.v
@@ -26,6 +26,8 @@ pub struct ButtonConfig {
 	text      string
 	icon_path string
 	onclick   ButtonClickFn
+	x         int
+	y         int
 	height    int
 	width     int
 	z_index   int
@@ -89,6 +91,8 @@ fn (mut b Button) init(parent Layout) {
 pub fn button(c ButtonConfig) &Button {
 	mut b := &Button{
 		id: c.id
+		x: c.x
+		y: c.y
 		width_: c.width
 		height_: c.height
 		z_index: c.z_index

--- a/dropdown.v
+++ b/dropdown.v
@@ -193,7 +193,6 @@ fn dd_click(mut dd Dropdown, e &MouseEvent, zzz voidptr) {
 	offset_start(mut dd)
 	if e.y >= dd.y && e.y <= dd.y + dd.dropdown_height && e.x >= dd.x && e.x <= dd.x + dd.width {
 		dd.open_drawer()
-	
 	// Check if the items length is greater than zero so that a division by zero error doesn't occur
 	} else if dd.open && dd.items.len > 0 {
 		th := dd.y + (dd.items.len * dd.dropdown_height)

--- a/ui.v
+++ b/ui.v
@@ -123,8 +123,8 @@ pub:
 
 pub struct MouseMoveEvent {
 pub:
-	x            f64
-	y            f64
+	x            int
+	y            int
 	mouse_button int
 	// TODO enum
 }

--- a/window.v
+++ b/window.v
@@ -480,8 +480,8 @@ fn window_resize(event gg.Event, ui &UI) {
 fn window_mouse_move(event gg.Event, ui &UI) {
 	mut window := ui.window
 	e := MouseMoveEvent{
-		x: event.mouse_x / ui.gg.scale
-		y: event.mouse_y / ui.gg.scale
+		x: int(event.mouse_x / ui.gg.scale)
+		y: int(event.mouse_y / ui.gg.scale)
 		mouse_button: int(event.mouse_button)
 	}
 	if window.drag_activated {
@@ -644,8 +644,8 @@ fn window_touch_up(event gg.Event, ui &UI) {
 fn window_touch_move(event gg.Event, ui &UI) {
 	window := ui.window
 	e := MouseMoveEvent{
-		x: f64(window.touch.move.pos.x)
-		y: f64(window.touch.move.pos.y)
+		x: int(window.touch.move.pos.x)
+		y: int(window.touch.move.pos.y)
 		mouse_button: window.touch.button
 	}
 	if window.mouse_move_fn != voidptr(0) {


### PR DESCRIPTION
Fixed Dropdown from crashing when there was no items.
Arrow now flips when Dropdown is open.
Fixed MouseMoveEvent where it was returning the wrong mouse position.
Added position Dropdown and Button config struct.