### PR TITLE
fix on_mouse_down

### DIFF
--- a/window.v
+++ b/window.v
@@ -551,7 +551,7 @@ fn window_mouse_down(event gg.Event, mut ui UI) {
 		ui.btn_down[int(event.mouse_button)] = true
 	}
 	if window.mouse_down_fn != voidptr(0) { // && action == voidptr(0) {
-		// window.mouse_down_fn(e, window)
+		window.mouse_down_fn(e, window)
 	}
 	/*
 	for child in window.children {


### PR DESCRIPTION
Re-enable the `on_mouse_down` callback as currently there is no alternative.

Regression in: https://github.com/vlang/ui/commit/0f6474493fe45c89134e55b2b43f203d42e47e18