### PR TITLE
fix android default font path

### DIFF
--- a/examples/demo_row_layout.v
+++ b/examples/demo_row_layout.v
@@ -19,8 +19,8 @@ mut:
 fn main() {
 	mut app := &App{}
 	app.sizes = {
-		'100':            100.
-		'20':             20.
+		'100':            100.0
+		'20':             20.0
 		'.3':             .3
 		'ui.stretch':     ui.stretch
 		'1.5*ui.stretch': 1.5 * ui.stretch

--- a/examples/rgb_color.v
+++ b/examples/rgb_color.v
@@ -141,7 +141,7 @@ fn main() {
 						}
 						spacing: .3
 						heights: ui.compact
-						widths: 30.
+						widths: 30.0
 						children: [app.r_textbox, app.g_textbox, app.b_textbox]
 					),
 					ui.row(
@@ -152,7 +152,7 @@ fn main() {
 							bottom: 5
 						}
 						spacing: .3
-						widths: 30.
+						widths: 30.0
 						children: [app.r_slider, app.g_slider, app.b_slider]
 					),
 					ui.row(
@@ -163,7 +163,7 @@ fn main() {
 							bottom: 5
 						}
 						spacing: .3
-						widths: 30.
+						widths: 30.0
 						children: [app.r_label, app.g_label, app.b_label]
 					),
 				]

--- a/examples/slider_textbox.v
+++ b/examples/slider_textbox.v
@@ -80,7 +80,7 @@ fn main() {
 					ui.row(
 					margin: ui.Margin{50, 115, 30, 30}
 					spacing: 100
-					heights: 20.
+					heights: 20.0
 					children: [app.hor_textbox, app.vert_textbox]
 				),
 					ui.row(

--- a/examples/temperature.v
+++ b/examples/temperature.v
@@ -42,7 +42,7 @@ fn main() {
 				margin: ui.Margin{10, 10, 10, 10}
 				spacing: 10
 				widths: [.2, .3, .2, .3]
-				heights: 20.
+				heights: 20.0
 				children: [ui.label(text: 'Celsius'), app.txt_box_celsius,
 					ui.label(
 					text: 'Fahrenheit'

--- a/examples/users_resizable.v
+++ b/examples/users_resizable.v
@@ -124,7 +124,7 @@ fn main() {
 						ui.row(
 							id: 'btn_row'
 							widths: [.5, .2]
-							heights: 20.
+							heights: 20.0
 							spacing: .3
 							children: [
 								ui.button(

--- a/window.v
+++ b/window.v
@@ -408,13 +408,6 @@ pub fn window(cfg WindowConfig) &Window {
 	// register default color themes
 	window.register_default_color_themes()
 
-	mut font_path := ''
-	$if android {
-		font_path = 'fonts/RobotoMono-Regular.ttf'
-	} $else {
-		font_path = if cfg.font_path == '' { gg.system_font_path() } else { cfg.font_path }
-	}
-
 	gcontext := gg.new_context(
 		width: width
 		height: height
@@ -433,7 +426,7 @@ pub fn window(cfg WindowConfig) &Window {
 		// native_frame_fn: native_frame
 		event_fn: on_event
 		user_data: window
-		font_path: font_path
+		font_path: if cfg.font_path == '' { gg.system_font_path() } else { cfg.font_path }
 		custom_bold_font_path: cfg.custom_bold_font_path
 		init_fn: gg_init
 		cleanup_fn: gg_cleanup


### PR DESCRIPTION
`$if android { font_path = 'fonts/RobotoMono-Regular.ttf'` always requires `assets/fonts/RobotoMono-Regular.ttf` to be present.
But Android only requires `assets/foo_font.ttf` for custom font if needed.
And `gg.system_font_path()` correctly gets system font.
So removed what leads to confusion.
This fixes https://github.com/Larpon/jni/issues/7#issuecomment-908591761

Fixed some code-style issues.