### PR TITLE
Add remaining CanvasLayout shapes

### DIFF
--- a/extra_event_mngr.v
+++ b/extra_event_mngr.v
@@ -34,7 +34,7 @@ pub fn (mut em EventMngr) add_receiver(widget Widget, evt_types []string) {
 		// BUG: 'widget in em.receivers[events.on_mouse_down]' is failing
 		// WORKAROUND with id
 		if widget.id !in em.receivers[evt_type].map(it.id) {
-			em.receivers[events.on_mouse_down] << widget
+			em.receivers[.events.on_mouse_down] << widget
 			$if evt_mngr ? {
 				println('add receiver $widget.id for $evt_type')
 			}

--- a/extra_event_mngr.v
+++ b/extra_event_mngr.v
@@ -18,9 +18,7 @@ pub:
 	on_resize       string = 'on_resize'
 }
 
-pub const (
-	events = EventNames{}
-)
+pub const events = EventNames{}
 
 // Managing mouse (down) events for widgets
 struct EventMngr {
@@ -34,7 +32,7 @@ pub fn (mut em EventMngr) add_receiver(widget Widget, evt_types []string) {
 		// BUG: 'widget in em.receivers[events.on_mouse_down]' is failing
 		// WORKAROUND with id
 		if widget.id !in em.receivers[evt_type].map(it.id) {
-			em.receivers[.events.on_mouse_down] << widget
+			em.receivers[ui.events.on_mouse_down] << widget
 			$if evt_mngr ? {
 				println('add receiver $widget.id for $evt_type')
 			}

--- a/widget_canvaslayout.v
+++ b/widget_canvaslayout.v
@@ -564,7 +564,7 @@ pub fn (c &CanvasLayout) draw_circle_line(x f32, y f32, r int, segments int, col
 }
 
 pub fn (c &CanvasLayout) draw_circle_empty(x f32, y f32, r f32, color gx.Color) {
-	c.ui.gg.draw_circle_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, r, color)
+	c.ui.gg.draw_circle_empty(x + c.x + c.offset_x, y + c.y + c.offset_y, r, color)
 }
 
 pub fn (c &CanvasLayout) draw_circle_filled(x f32, y f32, r f32, color gx.Color) {

--- a/widget_canvaslayout.v
+++ b/widget_canvaslayout.v
@@ -586,11 +586,13 @@ pub fn (c &CanvasLayout) draw_slice_filled(x f32, y f32, r f32, start_angle f32,
 // ---- arc
 
 pub fn (c &CanvasLayout) draw_arc_empty(x f32, y f32, inner_radius f32, thickness f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
-	c.ui.gg.draw_arc_empty(x + c.x + c.offset_x, y + c.y + c.offset_y, inner_radius, thickness, start_angle, end_angle, segments, color)
+	c.ui.gg.draw_arc_empty(x + c.x + c.offset_x, y + c.y + c.offset_y, inner_radius, thickness,
+		start_angle, end_angle, segments, color)
 }
 
 pub fn (c &CanvasLayout) draw_arc_filled(x f32, y f32, inner_radius f32, thickness f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
-	c.ui.gg.draw_arc_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, inner_radius, thickness, start_angle, end_angle, segments, color)
+	c.ui.gg.draw_arc_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, inner_radius,
+		thickness, start_angle, end_angle, segments, color)
 }
 
 // ---- line
@@ -607,4 +609,3 @@ pub fn (c &CanvasLayout) draw_convex_poly(points []f32, color gx.Color) {
 
 pub fn (c &CanvasLayout) draw_empty_poly(points []f32, color gx.Color) {
 }
-

--- a/widget_canvaslayout.v
+++ b/widget_canvaslayout.v
@@ -485,7 +485,18 @@ pub fn (c &CanvasLayout) get_children() []Widget {
 	return c.children
 }
 
+pub fn (c &CanvasLayout) child_index_by_id(id string) int {
+	for i, child in c.children {
+		if child.id() == id {
+			return i
+		}
+	}
+	return -1
+}
+
 // Methods for delegating drawing methods relatively to canvas coordinates
+
+// ---- text
 
 pub fn (c &CanvasLayout) draw_text_def(x int, y int, text string) {
 	c.ui.gg.draw_text_def(x + c.x + c.offset_x, y + c.y + c.offset_y, text)
@@ -501,8 +512,11 @@ pub fn (c &CanvasLayout) draw_styled_text(x int, y int, text string, ts TextStyl
 	dtw.draw_styled_text(x + c.x + c.offset_x, y + c.y + c.offset_y, text, ts)
 }
 
-pub fn (c &CanvasLayout) draw_rect_filled(x f32, y f32, w f32, h f32, color gx.Color) {
-	c.ui.gg.draw_rect_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, w, h, color)
+// ---- triangle
+
+pub fn (c &CanvasLayout) draw_triangle_empty(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, color gx.Color) {
+	c.ui.gg.draw_triangle_empty(x + c.x + c.offset_x, y + c.y + c.offset_y, x2 + c.x + c.offset_x,
+		y2 + c.y + c.offset_y, x3 + c.x + c.offset_x, y3 + c.y + c.offset_y, color)
 }
 
 pub fn (c &CanvasLayout) draw_triangle_filled(x f32, y f32, x2 f32, y2 f32, x3 f32, y3 f32, color gx.Color) {
@@ -510,32 +524,24 @@ pub fn (c &CanvasLayout) draw_triangle_filled(x f32, y f32, x2 f32, y2 f32, x3 f
 		y2 + c.y + c.offset_y, x3 + c.x + c.offset_x, y3 + c.y + c.offset_y, color)
 }
 
+// ---- square
+
+pub fn (c &CanvasLayout) draw_square_empty(x f32, y f32, s f32, color gx.Color) {
+	c.draw_rect_empty(x, y, s, s, color)
+}
+
+pub fn (c &CanvasLayout) draw_square_filled(x f32, y f32, s f32, color gx.Color) {
+	c.draw_rect_filled(x, y, s, s, color)
+}
+
+// ---- rectangle
+
 pub fn (c &CanvasLayout) draw_rect_empty(x f32, y f32, w f32, h f32, color gx.Color) {
 	c.ui.gg.draw_rect_empty(x + c.x + c.offset_x, y + c.y + c.offset_y, w, h, color)
 }
 
-pub fn (c &CanvasLayout) draw_circle_line(x f32, y f32, r int, segments int, color gx.Color) {
-	c.ui.gg.draw_circle_line(x + c.x + c.offset_x, y + c.y + c.offset_y, r, segments,
-		color)
-}
-
-pub fn (c &CanvasLayout) draw_circle_filled(x f32, y f32, r f32, color gx.Color) {
-	c.ui.gg.draw_circle_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, r, color)
-}
-
-pub fn (c &CanvasLayout) draw_slice_empty(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, color gx.Color) {
-	c.ui.gg.draw_slice_empty(x + c.x + c.offset_x, y + c.y + c.offset_y, r, start_angle,
-		arc_angle, segments, color)
-}
-
-pub fn (c &CanvasLayout) draw_slice_filled(x f32, y f32, r f32, start_angle f32, arc_angle f32, segments int, color gx.Color) {
-	c.ui.gg.draw_slice_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, r, start_angle,
-		arc_angle, segments, color)
-}
-
-pub fn (c &CanvasLayout) draw_line(x f32, y f32, x2 f32, y2 f32, color gx.Color) {
-	c.ui.gg.draw_line(x + c.x + c.offset_x, y + c.y + c.offset_y, x2 + c.x + c.offset_x,
-		y2 + c.y + c.offset_y, color)
+pub fn (c &CanvasLayout) draw_rect_filled(x f32, y f32, w f32, h f32, color gx.Color) {
+	c.ui.gg.draw_rect_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, w, h, color)
 }
 
 pub fn (c &CanvasLayout) draw_rounded_rect_filled(x f32, y f32, w f32, h f32, radius f32, color gx.Color) {
@@ -550,17 +556,55 @@ pub fn (c &CanvasLayout) draw_rounded_rect_empty(x f32, y f32, w f32, h f32, rad
 		rad, border_color)
 }
 
+// ---- circle
+
+pub fn (c &CanvasLayout) draw_circle_line(x f32, y f32, r int, segments int, color gx.Color) {
+	c.ui.gg.draw_circle_line(x + c.x + c.offset_x, y + c.y + c.offset_y, r, segments,
+		color)
+}
+
+pub fn (c &CanvasLayout) draw_circle_empty(x f32, y f32, r f32, color gx.Color) {
+	c.ui.gg.draw_circle_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, r, color)
+}
+
+pub fn (c &CanvasLayout) draw_circle_filled(x f32, y f32, r f32, color gx.Color) {
+	c.ui.gg.draw_circle_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, r, color)
+}
+
+// ---- slice
+
+pub fn (c &CanvasLayout) draw_slice_empty(x f32, y f32, r f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
+	c.ui.gg.draw_slice_empty(x + c.x + c.offset_x, y + c.y + c.offset_y, r, start_angle,
+		end_angle, segments, color)
+}
+
+pub fn (c &CanvasLayout) draw_slice_filled(x f32, y f32, r f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
+	c.ui.gg.draw_slice_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, r, start_angle,
+		end_angle, segments, color)
+}
+
+// ---- arc
+
+pub fn (c &CanvasLayout) draw_arc_empty(x f32, y f32, inner_radius f32, thickness f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
+	c.ui.gg.draw_arc_empty(x + c.x + c.offset_x, y + c.y + c.offset_y, inner_radius, thickness, start_angle, end_angle, segments, color)
+}
+
+pub fn (c &CanvasLayout) draw_arc_filled(x f32, y f32, inner_radius f32, thickness f32, start_angle f32, end_angle f32, segments int, color gx.Color) {
+	c.ui.gg.draw_arc_filled(x + c.x + c.offset_x, y + c.y + c.offset_y, inner_radius, thickness, start_angle, end_angle, segments, color)
+}
+
+// ---- line
+
+pub fn (c &CanvasLayout) draw_line(x f32, y f32, x2 f32, y2 f32, color gx.Color) {
+	c.ui.gg.draw_line(x + c.x + c.offset_x, y + c.y + c.offset_y, x2 + c.x + c.offset_x,
+		y2 + c.y + c.offset_y, color)
+}
+
+// ---- polygon
+// TODO: What to do about canvas offset?
 pub fn (c &CanvasLayout) draw_convex_poly(points []f32, color gx.Color) {
 }
 
 pub fn (c &CanvasLayout) draw_empty_poly(points []f32, color gx.Color) {
 }
 
-pub fn (c &CanvasLayout) child_index_by_id(id string) int {
-	for i, child in c.children {
-		if child.id() == id {
-			return i
-		}
-	}
-	return -1
-}

--- a/window.v
+++ b/window.v
@@ -1502,6 +1502,7 @@ fn (mut w Window) focus_prev() {
 		Layout(w).set_focus_last()
 	}
 }
+
 pub fn (w &Window) always_on_top(val bool) {}
 
 fn (w &Window) draw() {}


### PR DESCRIPTION
This adds the following shapes:
- `draw_triangle_empty()`
- `draw_square_empty()`
- `draw_square_filled()`
- `draw_circle_empty()`
- `draw_arc_filled()`
- `draw_arc_empty()`

Slight reordering and organizing as well.