### PR TITLE
change nil to non keyword

### DIFF
--- a/src/widget_textbox.v
+++ b/src/widget_textbox.v
@@ -9,7 +9,7 @@ import time
 // import sokol.sapp
 
 enum SelectionDirection {
-	nil = 0
+	non = 0
 	left_to_right
 	right_to_left
 }


### PR DESCRIPTION
The recent `unsafe { nil }` change introduced `nil` as a keyword, so I replaced it with `non`. Don't know how this is actually used, but it doesn't seem as though it's referenced anywhere.