### PR TITLE
android: use os.NativeActivity

### DIFF
--- a/src/ui_android.c.v
+++ b/src/ui_android.c.v
@@ -1,9 +1,9 @@
 module ui
 
+import os
 import sokol.sapp
 
 #include <android/configuration.h>
-#include <android/native_activity.h>
 
 enum AndroidConfig {
 	orientation
@@ -20,15 +20,9 @@ fn C.AConfiguration_getTouchscreen(voidptr) u32
 fn C.AConfiguration_getScreenSize(voidptr) u32
 fn C.AConfiguration_getSdkVersion(voidptr) u32
 
-struct C.AAssetManager {}
-
-struct C.ANativeActivity {
-	assetManager voidptr
-}
-
 pub fn android_config(mode AndroidConfig) u32 {
 	config := C.AConfiguration_new()
-	activity := &C.ANativeActivity(sapp.android_get_native_activity())
+	activity := &os.NativeActivity(sapp.android_get_native_activity())
 	C.AConfiguration_fromAssetManager(config, activity.assetManager)
 	mut cfg := u32(0)
 	match mode {


### PR DESCRIPTION
Fixes this compile error:
```
v -os android -nocache -cg -d no_load_styles -cc clang -dump-modules "/tmp/v.modules" -dump-c-flags "/tmp/v.cflags" ~/.vmodules/ui/examples/rectangles.v
...
~/Projects/v/vlib/gg/gg_android_outside_termux.c.v:17:53: error: field `os.NativeActivity.assetManager` is not public
   15 |     config := C.AConfiguration_new()
   16 |     activity := &os.NativeActivity(sapp.android_get_native_activity())
   17 |     C.AConfiguration_fromAssetManager(config, activity.assetManager)
      |                                                        ~~~~~~~~~~~~
   18 |     density := C.AConfiguration_getDensity(config)
   19 |     C.AConfiguration_delete(config)
```