### PR TITLE
Fix naming to prevent shadowing

### DIFF
--- a/src/interface_drawtextwidget.v
+++ b/src/interface_drawtextwidget.v
@@ -137,19 +137,19 @@ pub fn (w DrawTextWidget) load_style_(d DrawDevice, ts TextStyle) {
 			int(ts.align), int(ts.vertical_align))
 	}
 	$if !screenshot ? {
-		gg := w.ui.gg
-		fons := gg.ft.fons
+		gg_ := w.ui.gg
+		fons := gg_.ft.fons
 		fons.set_font(w.ui.fonts.hash[ts.font_name])
 
-		scale := if gg.ft.scale == 0 { f32(1) } else { gg.ft.scale }
+		scale := if gg_.ft.scale == 0 { f32(1) } else { gg_.ft.scale }
 		size := if ts.mono { ts.size - 2 } else { ts.size }
 		fons.set_size(scale * f32(size))
-		gg.ft.fons.set_align(int(ts.align) | int(ts.vertical_align))
+		gg_.ft.fons.set_align(int(ts.align) | int(ts.vertical_align))
 		color := sfons.rgba(ts.color.r, ts.color.g, ts.color.b, ts.color.a)
 		if ts.color.a != 255 {
-			sgl.load_pipeline(gg.pipeline.alpha)
+			sgl.load_pipeline(gg_.pipeline.alpha)
 		}
-		gg.ft.fons.set_color(color)
+		gg_.ft.fons.set_color(color)
 		ascender := f32(0.0)
 		descender := f32(0.0)
 		lh := f32(0.0)

--- a/src/style_button.v
+++ b/src/style_button.v
@@ -41,18 +41,18 @@ pub fn button_style(p ButtonStyleParams) ButtonStyleParams {
 }
 
 pub fn (bs ButtonStyle) to_toml() string {
-	mut toml := map[string]toml.Any{}
-	toml['radius'] = bs.radius
-	toml['border_color'] = hex_color(bs.border_color)
-	toml['bg_color'] = hex_color(bs.bg_color)
-	toml['bg_color_pressed'] = hex_color(bs.bg_color_hover)
-	toml['bg_color_hover'] = hex_color(bs.bg_color_pressed)
-	toml['text_font_name'] = bs.text_font_name
-	toml['text_color'] = hex_color(bs.text_color)
-	toml['text_size'] = bs.text_size
-	toml['text_align'] = int(bs.text_align)
-	toml['text_vertical_align'] = int(bs.text_vertical_align)
-	return toml.to_toml()
+	mut toml_ := map[string]toml.Any{}
+	toml_['radius'] = bs.radius
+	toml_['border_color'] = hex_color(bs.border_color)
+	toml_['bg_color'] = hex_color(bs.bg_color)
+	toml_['bg_color_pressed'] = hex_color(bs.bg_color_hover)
+	toml_['bg_color_hover'] = hex_color(bs.bg_color_pressed)
+	toml_['text_font_name'] = bs.text_font_name
+	toml_['text_color'] = hex_color(bs.text_color)
+	toml_['text_size'] = bs.text_size
+	toml_['text_align'] = int(bs.text_align)
+	toml_['text_vertical_align'] = int(bs.text_vertical_align)
+	return toml_.to_toml()
 }
 
 pub fn (mut bs ButtonStyle) from_toml(a toml.Any) {

--- a/src/style_checkbox.v
+++ b/src/style_checkbox.v
@@ -37,16 +37,16 @@ pub fn checkbox_style(p CheckBoxStyleParams) CheckBoxStyleParams {
 }
 
 pub fn (cbs CheckBoxStyle) to_toml() string {
-	mut toml := map[string]toml.Any{}
-	toml['border_color'] = hex_color(cbs.border_color)
-	toml['bg_color'] = hex_color(cbs.bg_color)
-	toml['check_mode'] = cbs.check_mode
-	toml['text_font_name'] = cbs.text_font_name
-	toml['text_color'] = hex_color(cbs.text_color)
-	toml['text_size'] = cbs.text_size
-	toml['text_align'] = int(cbs.text_align)
-	toml['text_vertical_align'] = int(cbs.text_vertical_align)
-	return toml.to_toml()
+	mut toml_ := map[string]toml.Any{}
+	toml_['border_color'] = hex_color(cbs.border_color)
+	toml_['bg_color'] = hex_color(cbs.bg_color)
+	toml_['check_mode'] = cbs.check_mode
+	toml_['text_font_name'] = cbs.text_font_name
+	toml_['text_color'] = hex_color(cbs.text_color)
+	toml_['text_size'] = cbs.text_size
+	toml_['text_align'] = int(cbs.text_align)
+	toml_['text_vertical_align'] = int(cbs.text_vertical_align)
+	return toml_.to_toml()
 }
 
 pub fn (mut cbs CheckBoxStyle) from_toml(a toml.Any) {

--- a/src/style_dropdown.v
+++ b/src/style_dropdown.v
@@ -39,12 +39,12 @@ pub fn dropdown_style(p DropdownStyleParams) DropdownStyleParams {
 }
 
 pub fn (dds DropdownStyle) to_toml() string {
-	mut toml := map[string]toml.Any{}
-	toml['bg_color'] = hex_color(dds.bg_color)
-	toml['border_color'] = hex_color(dds.border_color)
-	toml['focus_color'] = hex_color(dds.focus_color)
-	toml['drawer_color'] = hex_color(dds.drawer_color)
-	return toml.to_toml()
+	mut toml_ := map[string]toml.Any{}
+	toml_['bg_color'] = hex_color(dds.bg_color)
+	toml_['border_color'] = hex_color(dds.border_color)
+	toml_['focus_color'] = hex_color(dds.focus_color)
+	toml_['drawer_color'] = hex_color(dds.drawer_color)
+	return toml_.to_toml()
 }
 
 pub fn (mut dds DropdownStyle) from_toml(a toml.Any) {

--- a/src/style_label.v
+++ b/src/style_label.v
@@ -19,13 +19,13 @@ pub mut:
 }
 
 pub fn (ls LabelStyle) to_toml() string {
-	mut toml := map[string]toml.Any{}
-	toml['text_font_name'] = ls.text_font_name
-	toml['text_color'] = hex_color(ls.text_color)
-	toml['text_size'] = ls.text_size
-	toml['text_align'] = int(ls.text_align)
-	toml['text_vertical_align'] = int(ls.text_vertical_align)
-	return toml.to_toml()
+	mut toml_ := map[string]toml.Any{}
+	toml_['text_font_name'] = ls.text_font_name
+	toml_['text_color'] = hex_color(ls.text_color)
+	toml_['text_size'] = ls.text_size
+	toml_['text_align'] = int(ls.text_align)
+	toml_['text_vertical_align'] = int(ls.text_vertical_align)
+	return toml_.to_toml()
 }
 
 pub fn (mut ls LabelStyle) from_toml(a toml.Any) {

--- a/src/style_layouts.v
+++ b/src/style_layouts.v
@@ -35,10 +35,10 @@ pub fn canvaslayout_style(p CanvasLayoutStyleParams) CanvasLayoutStyleParams {
 }
 
 pub fn (ls CanvasLayoutStyle) to_toml() string {
-	mut toml := map[string]toml.Any{}
-	toml['bg_radius'] = ls.bg_radius
-	toml['bg_color'] = hex_color(ls.bg_color)
-	return toml.to_toml()
+	mut toml_ := map[string]toml.Any{}
+	toml_['bg_radius'] = ls.bg_radius
+	toml_['bg_color'] = hex_color(ls.bg_color)
+	return toml_.to_toml()
 }
 
 pub fn (mut ls CanvasLayoutStyle) from_toml(a toml.Any) {
@@ -138,10 +138,10 @@ pub fn stack_style(p StackStyleParams) StackStyleParams {
 }
 
 pub fn (ls StackStyle) to_toml() string {
-	mut toml := map[string]toml.Any{}
-	toml['bg_radius'] = ls.bg_radius
-	toml['bg_color'] = hex_color(ls.bg_color)
-	return toml.to_toml()
+	mut toml_ := map[string]toml.Any{}
+	toml_['bg_radius'] = ls.bg_radius
+	toml_['bg_color'] = hex_color(ls.bg_color)
+	return toml_.to_toml()
 }
 
 pub fn (mut ls StackStyle) from_toml(a toml.Any) {

--- a/src/style_progressbar.v
+++ b/src/style_progressbar.v
@@ -28,12 +28,12 @@ pub fn progressbar_style(p ProgressBarStyleParams) ProgressBarStyleParams {
 }
 
 pub fn (pbs ProgressBarStyle) to_toml() string {
-	mut toml := map[string]toml.Any{}
-	toml['color'] = hex_color(pbs.color)
-	toml['border_color'] = hex_color(pbs.border_color)
-	toml['bg_color'] = hex_color(pbs.bg_color)
-	toml['bg_border_color'] = hex_color(pbs.bg_border_color)
-	return toml.to_toml()
+	mut toml_ := map[string]toml.Any{}
+	toml_['color'] = hex_color(pbs.color)
+	toml_['border_color'] = hex_color(pbs.border_color)
+	toml_['bg_color'] = hex_color(pbs.bg_color)
+	toml_['bg_border_color'] = hex_color(pbs.bg_border_color)
+	return toml_.to_toml()
 }
 
 pub fn (mut pbs ProgressBarStyle) from_toml(a toml.Any) {

--- a/src/tool_settings.v
+++ b/src/tool_settings.v
@@ -24,10 +24,10 @@ fn printed_toml(v toml.Any, p PrintTomlParams) string {
 	for k, e in am {
 		title := if p.title == '' { k } else { '${p.title}.${k}' }
 		indent := ['  '].repeat(title.split('.').len - 1).join('')
-		toml := e.as_map().to_toml()
-		if toml[0..4] == '0 = ' {
+		toml_ := e.as_map().to_toml()
+		if toml_[0..4] == '0 = ' {
 			out += '${indent}${k} = ${e.to_toml()}\n'
-		} else if toml.contains('{') {
+		} else if toml_.contains('{') {
 			// map
 			out += printed_toml(e.as_map(),
 				title: title
@@ -35,7 +35,7 @@ fn printed_toml(v toml.Any, p PrintTomlParams) string {
 		} else {
 			out += '${indent}[${title}]\n'
 			mut res := ''
-			for l in toml.split('\n') {
+			for l in toml_.split('\n') {
 				res += '${indent}${l}\n'
 			}
 			out += res


### PR DESCRIPTION
From https://github.com/vlang/v/pull/17197, fix variable naming to prevent import symbol shadowing.