### PR TITLE
refactor: rename vars and params to prevent module name shadowing

### DIFF
--- a/src/button.v
+++ b/src/button.v
@@ -148,8 +148,8 @@ pub fn button(c ButtonParams) &Button {
 
 fn (mut b Button) init(parent Layout) {
 	b.parent = parent
-	ui := parent.get_ui()
-	b.ui = ui
+	gui := parent.get_ui()
+	b.ui = gui
 	if b.use_icon {
 		if mut b.ui.dd is DrawDeviceContext {
 			if img := b.ui.dd.create_image(b.icon_path) {
@@ -160,7 +160,7 @@ fn (mut b Button) init(parent Layout) {
 	b.load_style()
 	b.set_text_size()
 	if b.tooltip.text != '' {
-		mut win := ui.window
+		mut win := gui.window
 		win.tooltip.append(b, b.tooltip)
 	}
 	mut subscriber := parent.get_subscriber()

--- a/src/button.v
+++ b/src/button.v
@@ -148,8 +148,8 @@ pub fn button(c ButtonParams) &Button {
 
 fn (mut b Button) init(parent Layout) {
 	b.parent = parent
-	gui := parent.get_ui()
-	b.ui = gui
+	u := parent.get_ui()
+	b.ui = u
 	if b.use_icon {
 		if mut b.ui.dd is DrawDeviceContext {
 			if img := b.ui.dd.create_image(b.icon_path) {
@@ -160,7 +160,7 @@ fn (mut b Button) init(parent Layout) {
 	b.load_style()
 	b.set_text_size()
 	if b.tooltip.text != '' {
-		mut win := gui.window
+		mut win := u.window
 		win.tooltip.append(b, b.tooltip)
 	}
 	mut subscriber := parent.get_subscriber()

--- a/src/canvas.v
+++ b/src/canvas.v
@@ -53,8 +53,8 @@ pub fn canvas(c CanvasParams) &Canvas {
 
 fn (mut c Canvas) init(parent Layout) {
 	c.parent = parent
-	ui := parent.get_ui()
-	c.ui = ui
+	gui := parent.get_ui()
+	c.ui = gui
 }
 
 [manualfree]

--- a/src/canvas.v
+++ b/src/canvas.v
@@ -53,8 +53,8 @@ pub fn canvas(c CanvasParams) &Canvas {
 
 fn (mut c Canvas) init(parent Layout) {
 	c.parent = parent
-	gui := parent.get_ui()
-	c.ui = gui
+	u := parent.get_ui()
+	c.ui = u
 }
 
 [manualfree]

--- a/src/dropdown.v
+++ b/src/dropdown.v
@@ -85,8 +85,8 @@ pub fn dropdown(c DropdownParams) &Dropdown {
 
 pub fn (mut dd Dropdown) init(parent Layout) {
 	dd.parent = parent
-	ui := parent.get_ui()
-	dd.ui = ui
+	gui := parent.get_ui()
+	dd.ui = gui
 	dd.load_style()
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_click, dd_click, dd)

--- a/src/dropdown.v
+++ b/src/dropdown.v
@@ -85,8 +85,8 @@ pub fn dropdown(c DropdownParams) &Dropdown {
 
 pub fn (mut dd Dropdown) init(parent Layout) {
 	dd.parent = parent
-	gui := parent.get_ui()
-	dd.ui = gui
+	u := parent.get_ui()
+	dd.ui = u
 	dd.load_style()
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_click, dd_click, dd)

--- a/src/extra_debug.v
+++ b/src/extra_debug.v
@@ -23,16 +23,16 @@ fn debug_draw_bb_stack(s &Stack) {
 		col)
 }
 
-fn debug_draw_bb_widget(mut wi Widget, ui &UI) {
+fn debug_draw_bb_widget(mut wi Widget, gui &UI) {
 	col := gx.black
 	w, h := wi.size()
 	println('bb: ${wi.type_name()} (${wi.x}, ${wi.y} ,${w}, ${h})')
-	ui.dd.draw_rect_empty(wi.x, wi.y, w, h, col)
+	gui.dd.draw_rect_empty(wi.x, wi.y, w, h, col)
 }
 
-fn debug_draw_bb_text(x int, y int, w int, h int, ui &UI) {
+fn debug_draw_bb_text(x int, y int, w int, h int, gui &UI) {
 	col := gx.gray
-	ui.dd.draw_rect_empty(x, y, w, h, col)
+	gui.dd.draw_rect_empty(x, y, w, h, col)
 }
 
 // Debug function

--- a/src/extra_debug.v
+++ b/src/extra_debug.v
@@ -23,16 +23,16 @@ fn debug_draw_bb_stack(s &Stack) {
 		col)
 }
 
-fn debug_draw_bb_widget(mut wi Widget, gui &UI) {
+fn debug_draw_bb_widget(mut wi Widget, u &UI) {
 	col := gx.black
 	w, h := wi.size()
 	println('bb: ${wi.type_name()} (${wi.x}, ${wi.y} ,${w}, ${h})')
-	gui.dd.draw_rect_empty(wi.x, wi.y, w, h, col)
+	u.dd.draw_rect_empty(wi.x, wi.y, w, h, col)
 }
 
-fn debug_draw_bb_text(x int, y int, w int, h int, gui &UI) {
+fn debug_draw_bb_text(x int, y int, w int, h int, u &UI) {
 	col := gx.gray
-	gui.dd.draw_rect_empty(x, y, w, h, col)
+	u.dd.draw_rect_empty(x, y, w, h, col)
 }
 
 // Debug function

--- a/src/extra_text.v
+++ b/src/extra_text.v
@@ -33,10 +33,10 @@ fn word_wrap_text_to_lines(s string, max_line_length int) []string {
 	return word_wrapped_lines
 }
 
-fn text_lines_size(lines []string, ui &UI) (int, int) {
+fn text_lines_size(lines []string, gui &UI) (int, int) {
 	mut width, mut height := 0, 0
 	mut tw, mut th := 0, 0
-	dd := ui.dd
+	dd := gui.dd
 	for line in lines {
 		tw, th = dd.text_size(line)
 		// println("tt line: $line -> ($tw, $th)")

--- a/src/extra_text.v
+++ b/src/extra_text.v
@@ -33,10 +33,10 @@ fn word_wrap_text_to_lines(s string, max_line_length int) []string {
 	return word_wrapped_lines
 }
 
-fn text_lines_size(lines []string, gui &UI) (int, int) {
+fn text_lines_size(lines []string, u &UI) (int, int) {
 	mut width, mut height := 0, 0
 	mut tw, mut th := 0, 0
-	dd := gui.dd
+	dd := u.dd
 	for line in lines {
 		tw, th = dd.text_size(line)
 		// println("tt line: $line -> ($tw, $th)")

--- a/src/grid.v
+++ b/src/grid.v
@@ -47,8 +47,8 @@ pub fn grid(c GridParams) &Grid {
 
 fn (mut gv Grid) init(parent Layout) {
 	gv.parent = parent
-	gui := parent.get_ui()
-	gv.ui = gui
+	u := parent.get_ui()
+	gv.ui = u
 }
 
 [manualfree]

--- a/src/grid.v
+++ b/src/grid.v
@@ -47,8 +47,8 @@ pub fn grid(c GridParams) &Grid {
 
 fn (mut gv Grid) init(parent Layout) {
 	gv.parent = parent
-	ui := parent.get_ui()
-	gv.ui = ui
+	gui := parent.get_ui()
+	gv.ui = gui
 }
 
 [manualfree]

--- a/src/interface_scrollable.v
+++ b/src/interface_scrollable.v
@@ -471,8 +471,8 @@ pub mut:
 
 fn (mut sv ScrollView) init(parent Layout) {
 	mut widget := sv.widget
-	wui := widget.ui // get_ui()
-	sv.ui = wui
+	u := widget.ui // get_ui()
+	sv.ui = u
 	sv.parent = parent
 
 	mut subscriber := parent.get_subscriber()

--- a/src/interface_scrollable.v
+++ b/src/interface_scrollable.v
@@ -471,8 +471,8 @@ pub mut:
 
 fn (mut sv ScrollView) init(parent Layout) {
 	mut widget := sv.widget
-	ui := widget.ui // get_ui()
-	sv.ui = ui
+	wui := widget.ui // get_ui()
+	sv.ui = wui
 	sv.parent = parent
 
 	mut subscriber := parent.get_subscriber()

--- a/src/label.v
+++ b/src/label.v
@@ -68,8 +68,8 @@ pub fn label(c LabelParams) &Label {
 }
 
 fn (mut l Label) init(parent Layout) {
-	ui := parent.get_ui()
-	l.ui = ui
+	gui := parent.get_ui()
+	l.ui = gui
 	l.load_style()
 	// l.init_style()
 	l.init_size()

--- a/src/label.v
+++ b/src/label.v
@@ -68,8 +68,8 @@ pub fn label(c LabelParams) &Label {
 }
 
 fn (mut l Label) init(parent Layout) {
-	gui := parent.get_ui()
-	l.ui = gui
+	u := parent.get_ui()
+	l.ui = u
 	l.load_style()
 	// l.init_style()
 	l.init_size()

--- a/src/layout_box.v
+++ b/src/layout_box.v
@@ -137,8 +137,8 @@ pub fn box_layout(c BoxLayoutParams) &BoxLayout {
 // TODO: documentation
 pub fn (mut b BoxLayout) init(parent Layout) {
 	b.parent = parent
-	mut ui := parent.get_ui()
-	b.ui = ui
+	mut gui := parent.get_ui()
+	b.ui = gui
 	for _, mut child in b.children {
 		// DON'T DO THAT: child.id = b.child_id[i]
 		// println('$i) gl init child ${child.id} ')

--- a/src/layout_box.v
+++ b/src/layout_box.v
@@ -137,8 +137,8 @@ pub fn box_layout(c BoxLayoutParams) &BoxLayout {
 // TODO: documentation
 pub fn (mut b BoxLayout) init(parent Layout) {
 	b.parent = parent
-	mut gui := parent.get_ui()
-	b.ui = gui
+	mut u := parent.get_ui()
+	b.ui = u
 	for _, mut child in b.children {
 		// DON'T DO THAT: child.id = b.child_id[i]
 		// println('$i) gl init child ${child.id} ')

--- a/src/layout_canvas.v
+++ b/src/layout_canvas.v
@@ -189,8 +189,8 @@ fn (mut c CanvasLayout) build(win &Window) {
 
 fn (mut c CanvasLayout) init(parent Layout) {
 	c.parent = parent
-	ui := parent.get_ui()
-	c.ui = ui
+	gui := parent.get_ui()
+	c.ui = gui
 	c.init_size()
 	// IMPORTANT: Subscriber needs here to be before initialization of all its children
 	mut subscriber := parent.get_subscriber()
@@ -222,7 +222,7 @@ fn (mut c CanvasLayout) init(parent Layout) {
 	}
 	c.load_style()
 
-	c.set_adjusted_size(ui)
+	c.set_adjusted_size(gui)
 	c.set_children_pos()
 	c.set_root_layout()
 

--- a/src/layout_canvas.v
+++ b/src/layout_canvas.v
@@ -189,8 +189,8 @@ fn (mut c CanvasLayout) build(win &Window) {
 
 fn (mut c CanvasLayout) init(parent Layout) {
 	c.parent = parent
-	gui := parent.get_ui()
-	c.ui = gui
+	u := parent.get_ui()
+	c.ui = u
 	c.init_size()
 	// IMPORTANT: Subscriber needs here to be before initialization of all its children
 	mut subscriber := parent.get_subscriber()
@@ -222,7 +222,7 @@ fn (mut c CanvasLayout) init(parent Layout) {
 	}
 	c.load_style()
 
-	c.set_adjusted_size(gui)
+	c.set_adjusted_size(u)
 	c.set_children_pos()
 	c.set_root_layout()
 

--- a/src/layout_group.v
+++ b/src/layout_group.v
@@ -70,8 +70,8 @@ pub fn group(c GroupParams) &Group {
 
 fn (mut g Group) init(parent Layout) {
 	g.parent = parent
-	gui := parent.get_ui()
-	g.ui = gui
+	u := parent.get_ui()
+	g.ui = u
 	g.decode_size()
 	for mut child in g.children {
 		child.init(g)
@@ -201,7 +201,7 @@ fn (g &Group) get_subscriber() &eventbus.Subscriber {
 	return parent.get_subscriber()
 }
 
-fn (mut g Group) set_adjusted_size(i int, gui &UI) {
+fn (mut g Group) set_adjusted_size(i int, u &UI) {
 	mut h, mut w := 0, 0
 	for mut child in g.children {
 		mut child_width, mut child_height := child.size()

--- a/src/layout_group.v
+++ b/src/layout_group.v
@@ -70,8 +70,8 @@ pub fn group(c GroupParams) &Group {
 
 fn (mut g Group) init(parent Layout) {
 	g.parent = parent
-	ui := parent.get_ui()
-	g.ui = ui
+	gui := parent.get_ui()
+	g.ui = gui
 	g.decode_size()
 	for mut child in g.children {
 		child.init(g)
@@ -201,7 +201,7 @@ fn (g &Group) get_subscriber() &eventbus.Subscriber {
 	return parent.get_subscriber()
 }
 
-fn (mut g Group) set_adjusted_size(i int, ui &UI) {
+fn (mut g Group) set_adjusted_size(i int, gui &UI) {
 	mut h, mut w := 0, 0
 	for mut child in g.children {
 		mut child_width, mut child_height := child.size()

--- a/src/listbox.v
+++ b/src/listbox.v
@@ -136,8 +136,8 @@ pub fn listbox(c ListBoxParams) &ListBox {
 
 fn (mut lb ListBox) init(parent Layout) {
 	lb.parent = parent
-	gui := parent.get_ui()
-	lb.ui = gui
+	u := parent.get_ui()
+	lb.ui = u
 	lb.init_style()
 	mut dtw := DrawTextWidget(lb)
 	dtw.load_style()

--- a/src/listbox.v
+++ b/src/listbox.v
@@ -136,8 +136,8 @@ pub fn listbox(c ListBoxParams) &ListBox {
 
 fn (mut lb ListBox) init(parent Layout) {
 	lb.parent = parent
-	ui := parent.get_ui()
-	lb.ui = ui
+	gui := parent.get_ui()
+	lb.ui = gui
 	lb.init_style()
 	mut dtw := DrawTextWidget(lb)
 	dtw.load_style()

--- a/src/menu.v
+++ b/src/menu.v
@@ -120,8 +120,8 @@ fn (mut m Menu) build(mut win Window) {
 
 fn (mut m Menu) init(parent Layout) {
 	m.parent = parent
-	gui := parent.get_ui()
-	m.ui = gui
+	u := parent.get_ui()
+	m.ui = u
 	m.update_size()
 	if m.is_root_menu() {
 		m.propagate_connection()

--- a/src/menu.v
+++ b/src/menu.v
@@ -120,8 +120,8 @@ fn (mut m Menu) build(mut win Window) {
 
 fn (mut m Menu) init(parent Layout) {
 	m.parent = parent
-	ui := parent.get_ui()
-	m.ui = ui
+	gui := parent.get_ui()
+	m.ui = gui
 	m.update_size()
 	if m.is_root_menu() {
 		m.propagate_connection()

--- a/src/picture.v
+++ b/src/picture.v
@@ -73,8 +73,8 @@ pub fn picture(c PictureParams) &Picture {
 
 fn (mut pic Picture) init(parent Layout) {
 	pic.parent = parent
-	mut gui := parent.get_ui()
-	pic.ui = gui
+	mut u := parent.get_ui()
+	pic.ui = u
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_click, pic_click, pic)
 	subscriber.subscribe_method(events.on_mouse_down, pic_mouse_down, pic)
@@ -82,23 +82,23 @@ fn (mut pic Picture) init(parent Layout) {
 	/*
 	if pic.image.width > 0 {
 		// .image was set by the user, skip path  TODO
-		ui.resource_cache[pic.path] = pic.image
+		u.resource_cache[pic.path] = pic.image
 		return
 	}
 	*/
-	if gui.has_img(pic.path) {
-		pic.image = gui.img(pic.path)
+	if u.has_img(pic.path) {
+		pic.image = u.img(pic.path)
 	} else {
 		if !os.exists(pic.path) {
 			eprintln('V UI: picture file "${pic.path}" not found')
 		}
-		if !pic.use_cache && pic.path in gui.resource_cache {
-			pic.image = gui.resource_cache[pic.path]
+		if !pic.use_cache && pic.path in u.resource_cache {
+			pic.image = u.resource_cache[pic.path]
 		} else if mut pic.ui.dd is DrawDeviceContext {
 			dd := pic.ui.dd
 			if img := dd.create_image(pic.path) {
 				pic.image = img
-				gui.resource_cache[pic.path] = pic.image
+				u.resource_cache[pic.path] = pic.image
 			}
 		}
 	}
@@ -114,7 +114,7 @@ fn (mut pic Picture) init(parent Layout) {
 		pic.height = pic.image.height
 	}
 	if pic.tooltip.text != '' {
-		mut win := gui.window
+		mut win := u.window
 		win.tooltip.append(pic, pic.tooltip)
 	}
 }

--- a/src/picture.v
+++ b/src/picture.v
@@ -73,8 +73,8 @@ pub fn picture(c PictureParams) &Picture {
 
 fn (mut pic Picture) init(parent Layout) {
 	pic.parent = parent
-	mut ui := parent.get_ui()
-	pic.ui = ui
+	mut gui := parent.get_ui()
+	pic.ui = gui
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_click, pic_click, pic)
 	subscriber.subscribe_method(events.on_mouse_down, pic_mouse_down, pic)
@@ -86,19 +86,19 @@ fn (mut pic Picture) init(parent Layout) {
 		return
 	}
 	*/
-	if ui.has_img(pic.path) {
-		pic.image = ui.img(pic.path)
+	if gui.has_img(pic.path) {
+		pic.image = gui.img(pic.path)
 	} else {
 		if !os.exists(pic.path) {
 			eprintln('V UI: picture file "${pic.path}" not found')
 		}
-		if !pic.use_cache && pic.path in ui.resource_cache {
-			pic.image = ui.resource_cache[pic.path]
+		if !pic.use_cache && pic.path in gui.resource_cache {
+			pic.image = gui.resource_cache[pic.path]
 		} else if mut pic.ui.dd is DrawDeviceContext {
 			dd := pic.ui.dd
 			if img := dd.create_image(pic.path) {
 				pic.image = img
-				ui.resource_cache[pic.path] = pic.image
+				gui.resource_cache[pic.path] = pic.image
 			}
 		}
 	}
@@ -114,7 +114,7 @@ fn (mut pic Picture) init(parent Layout) {
 		pic.height = pic.image.height
 	}
 	if pic.tooltip.text != '' {
-		mut win := ui.window
+		mut win := gui.window
 		win.tooltip.append(pic, pic.tooltip)
 	}
 }

--- a/src/progressbar.v
+++ b/src/progressbar.v
@@ -59,8 +59,8 @@ pub fn progressbar(c ProgressBarParams) &ProgressBar {
 
 fn (mut pb ProgressBar) init(parent Layout) {
 	pb.parent = parent
-	gui := parent.get_ui()
-	pb.ui = gui
+	u := parent.get_ui()
+	pb.ui = u
 	pb.load_style()
 }
 

--- a/src/progressbar.v
+++ b/src/progressbar.v
@@ -59,8 +59,8 @@ pub fn progressbar(c ProgressBarParams) &ProgressBar {
 
 fn (mut pb ProgressBar) init(parent Layout) {
 	pb.parent = parent
-	ui := parent.get_ui()
-	pb.ui = ui
+	gui := parent.get_ui()
+	pb.ui = gui
 	pb.load_style()
 }
 

--- a/src/radio.v
+++ b/src/radio.v
@@ -104,8 +104,8 @@ pub fn radio(c RadioParams) &Radio {
 
 fn (mut r Radio) init(parent Layout) {
 	r.parent = parent
-	gui := parent.get_ui()
-	r.ui = gui
+	u := parent.get_ui()
+	r.ui = u
 	// Get max value text width
 	if r.width == 0 {
 		r.set_size_from_values()

--- a/src/radio.v
+++ b/src/radio.v
@@ -104,8 +104,8 @@ pub fn radio(c RadioParams) &Radio {
 
 fn (mut r Radio) init(parent Layout) {
 	r.parent = parent
-	ui := parent.get_ui()
-	r.ui = ui
+	gui := parent.get_ui()
+	r.ui = gui
 	// Get max value text width
 	if r.width == 0 {
 		r.set_size_from_values()

--- a/src/rectangle.v
+++ b/src/rectangle.v
@@ -89,8 +89,8 @@ pub fn spacing(c RectangleParams) &Rectangle {
 
 fn (mut r Rectangle) init(parent Layout) {
 	r.parent = parent
-	gui := parent.get_ui()
-	r.ui = gui
+	u := parent.get_ui()
+	r.ui = u
 	// r.init_style()
 	r.load_style()
 }

--- a/src/rectangle.v
+++ b/src/rectangle.v
@@ -89,8 +89,8 @@ pub fn spacing(c RectangleParams) &Rectangle {
 
 fn (mut r Rectangle) init(parent Layout) {
 	r.parent = parent
-	ui := parent.get_ui()
-	r.ui = ui
+	gui := parent.get_ui()
+	r.ui = gui
 	// r.init_style()
 	r.load_style()
 }

--- a/src/slider.v
+++ b/src/slider.v
@@ -110,8 +110,8 @@ pub fn slider(c SliderParams) &Slider {
 
 fn (mut s Slider) init(parent Layout) {
 	s.parent = parent
-	gui := parent.get_ui()
-	s.ui = gui
+	u := parent.get_ui()
+	s.ui = u
 	s.load_style()
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_click, slider_click, s)

--- a/src/slider.v
+++ b/src/slider.v
@@ -110,8 +110,8 @@ pub fn slider(c SliderParams) &Slider {
 
 fn (mut s Slider) init(parent Layout) {
 	s.parent = parent
-	ui := parent.get_ui()
-	s.ui = ui
+	gui := parent.get_ui()
+	s.ui = gui
 	s.load_style()
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_click, slider_click, s)

--- a/src/stack.v
+++ b/src/stack.v
@@ -177,8 +177,8 @@ fn (mut s Stack) build(win &Window) {
 
 pub fn (mut s Stack) init(parent Layout) {
 	s.parent = parent
-	mut ui := parent.get_ui()
-	s.ui = ui
+	gui := parent.get_ui()
+	s.ui = gui
 	s.init_size()
 	s.load_style()
 	// Init all children recursively

--- a/src/stack.v
+++ b/src/stack.v
@@ -177,8 +177,8 @@ fn (mut s Stack) build(win &Window) {
 
 pub fn (mut s Stack) init(parent Layout) {
 	s.parent = parent
-	gui := parent.get_ui()
-	s.ui = gui
+	u := parent.get_ui()
+	s.ui = u
 	s.init_size()
 	s.load_style()
 	// Init all children recursively

--- a/src/subwindow.v
+++ b/src/subwindow.v
@@ -98,8 +98,8 @@ pub fn (mut s SubWindow) cleanup() {
 	subscriber.unsubscribe_method(events.on_mouse_down, s)
 	subscriber.unsubscribe_method(events.on_mouse_move, s)
 	subscriber.unsubscribe_method(events.on_mouse_up, s)
-	mut gui := s.get_ui()
-	gui.window.evt_mngr.rm_receiver(s, [events.on_mouse_down])
+	mut u := s.get_ui()
+	u.window.evt_mngr.rm_receiver(s, [events.on_mouse_down])
 	unsafe { s.free() }
 }
 
@@ -247,7 +247,7 @@ pub fn (mut s SubWindow) update_layout() {
 	s.layout.update_layout()
 }
 
-fn (mut s SubWindow) set_adjusted_size(gui &UI) {
+fn (mut s SubWindow) set_adjusted_size(u &UI) {
 }
 
 fn (mut s SubWindow) point_inside_bar(x f64, y f64) bool {

--- a/src/subwindow.v
+++ b/src/subwindow.v
@@ -98,8 +98,8 @@ pub fn (mut s SubWindow) cleanup() {
 	subscriber.unsubscribe_method(events.on_mouse_down, s)
 	subscriber.unsubscribe_method(events.on_mouse_move, s)
 	subscriber.unsubscribe_method(events.on_mouse_up, s)
-	mut ui := s.get_ui()
-	ui.window.evt_mngr.rm_receiver(s, [events.on_mouse_down])
+	mut gui := s.get_ui()
+	gui.window.evt_mngr.rm_receiver(s, [events.on_mouse_down])
 	unsafe { s.free() }
 }
 
@@ -247,7 +247,7 @@ pub fn (mut s SubWindow) update_layout() {
 	s.layout.update_layout()
 }
 
-fn (mut s SubWindow) set_adjusted_size(ui &UI) {
+fn (mut s SubWindow) set_adjusted_size(gui &UI) {
 }
 
 fn (mut s SubWindow) point_inside_bar(x f64, y f64) bool {

--- a/src/switch.v
+++ b/src/switch.v
@@ -66,8 +66,8 @@ pub fn switcher(c SwitchParams) &Switch {
 
 fn (mut s Switch) init(parent Layout) {
 	s.parent = parent
-	ui := parent.get_ui()
-	s.ui = ui
+	gui := parent.get_ui()
+	s.ui = gui
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_key_down, sw_key_down, s)
 	subscriber.subscribe_method(events.on_click, sw_click, s)

--- a/src/switch.v
+++ b/src/switch.v
@@ -66,8 +66,8 @@ pub fn switcher(c SwitchParams) &Switch {
 
 fn (mut s Switch) init(parent Layout) {
 	s.parent = parent
-	gui := parent.get_ui()
-	s.ui = gui
+	u := parent.get_ui()
+	s.ui = u
 	mut subscriber := parent.get_subscriber()
 	subscriber.subscribe_method(events.on_key_down, sw_key_down, s)
 	subscriber.subscribe_method(events.on_click, sw_click, s)

--- a/src/textbox.v
+++ b/src/textbox.v
@@ -219,8 +219,8 @@ pub fn textbox(c TextBoxParams) &TextBox {
 
 pub fn (mut tb TextBox) init(parent Layout) {
 	tb.parent = parent
-	ui := parent.get_ui()
-	tb.ui = ui
+	gui := parent.get_ui()
+	tb.ui = gui
 	// tb.init_style()
 	tb.load_style()
 	// TODO: Maybe in a method later to allow font size update

--- a/src/textbox.v
+++ b/src/textbox.v
@@ -219,8 +219,8 @@ pub fn textbox(c TextBoxParams) &TextBox {
 
 pub fn (mut tb TextBox) init(parent Layout) {
 	tb.parent = parent
-	gui := parent.get_ui()
-	tb.ui = gui
+	u := parent.get_ui()
+	tb.ui = u
 	// tb.init_style()
 	tb.load_style()
 	// TODO: Maybe in a method later to allow font size update

--- a/src/tool_text_style.v
+++ b/src/tool_text_style.v
@@ -64,23 +64,23 @@ mut:
 	hash map[string]int
 }
 
-pub fn (mut ui UI) add_font(font_name string, font_path string) {
+pub fn (mut gui UI) add_font(font_name string, font_path string) {
 	$if fontset ? {
 		println('add font ${font_name} at ${font_path}')
 	}
-	if mut ui.dd is DrawDeviceContext {
+	if mut gui.dd is DrawDeviceContext {
 		// IMPORTANT: This fix issue that makes DrawTextFont not working for fontstash
 		// (in fons__getGlyph, added becomes 0)
-		ui.dd.ft.fons.reset_atlas(512, 512)
+		gui.dd.ft.fons.reset_atlas(512, 512)
 
 		bytes := os.read_bytes(font_path) or { []u8{} }
-		// gg := ui.gg
-		// mut f := ui.fonts
+		// gg := gui.gg
+		// mut f := gui.fonts
 		if bytes.len > 0 {
-			font_ := ui.dd.ft.fons.add_font_mem('sans', bytes, false)
+			font_ := gui.dd.ft.fons.add_font_mem('sans', bytes, false)
 			if font_ >= 0 {
-				ui.font_paths[font_name] = font_path
-				ui.fonts.hash[font_name] = font_
+				gui.font_paths[font_name] = font_path
+				gui.fonts.hash[font_name] = font_
 				$if fontset ? {
 					println('font ${font_} ${font_name} added (${font_path})')
 				}
@@ -100,12 +100,12 @@ pub fn (mut ui UI) add_font(font_name string, font_path string) {
 		}
 	}
 	$if fontset ? {
-		println('${ui.fonts}')
+		println('${gui.fonts}')
 	}
 }
 
 // define style to be used with drawtext method
-pub fn (mut ui UI) add_style(ts TextStyle) {
+pub fn (mut gui UI) add_style(ts TextStyle) {
 	mut id := ts.id
 	if id == '' {
 		if ts.font_name == '' {
@@ -114,7 +114,7 @@ pub fn (mut ui UI) add_style(ts TextStyle) {
 		}
 		id = ts.font_name
 	}
-	ui.text_styles[id] = TextStyle{
+	gui.text_styles[id] = TextStyle{
 		id: id
 		font_name: ts.font_name
 		color: ts.color

--- a/src/tool_text_style.v
+++ b/src/tool_text_style.v
@@ -64,23 +64,23 @@ mut:
 	hash map[string]int
 }
 
-pub fn (mut gui UI) add_font(font_name string, font_path string) {
+pub fn (mut u UI) add_font(font_name string, font_path string) {
 	$if fontset ? {
 		println('add font ${font_name} at ${font_path}')
 	}
-	if mut gui.dd is DrawDeviceContext {
+	if mut u.dd is DrawDeviceContext {
 		// IMPORTANT: This fix issue that makes DrawTextFont not working for fontstash
 		// (in fons__getGlyph, added becomes 0)
-		gui.dd.ft.fons.reset_atlas(512, 512)
+		u.dd.ft.fons.reset_atlas(512, 512)
 
 		bytes := os.read_bytes(font_path) or { []u8{} }
-		// gg := gui.gg
-		// mut f := gui.fonts
+		// gg := u.gg
+		// mut f := u.fonts
 		if bytes.len > 0 {
-			font_ := gui.dd.ft.fons.add_font_mem('sans', bytes, false)
+			font_ := u.dd.ft.fons.add_font_mem('sans', bytes, false)
 			if font_ >= 0 {
-				gui.font_paths[font_name] = font_path
-				gui.fonts.hash[font_name] = font_
+				u.font_paths[font_name] = font_path
+				u.fonts.hash[font_name] = font_
 				$if fontset ? {
 					println('font ${font_} ${font_name} added (${font_path})')
 				}
@@ -100,12 +100,12 @@ pub fn (mut gui UI) add_font(font_name string, font_path string) {
 		}
 	}
 	$if fontset ? {
-		println('${gui.fonts}')
+		println('${u.fonts}')
 	}
 }
 
 // define style to be used with drawtext method
-pub fn (mut gui UI) add_style(ts TextStyle) {
+pub fn (mut u UI) add_style(ts TextStyle) {
 	mut id := ts.id
 	if id == '' {
 		if ts.font_name == '' {
@@ -114,7 +114,7 @@ pub fn (mut gui UI) add_style(ts TextStyle) {
 		}
 		id = ts.font_name
 	}
-	gui.text_styles[id] = TextStyle{
+	u.text_styles[id] = TextStyle{
 		id: id
 		font_name: ts.font_name
 		color: ts.color

--- a/src/transition.v
+++ b/src/transition.v
@@ -55,8 +55,8 @@ pub fn transition(c TransitionParams) &Transition {
 
 fn (mut t Transition) init(parent Layout) {
 	t.parent = parent
-	ui := parent.get_ui()
-	t.ui = ui
+	gui := parent.get_ui()
+	t.ui = gui
 }
 
 [manualfree]

--- a/src/transition.v
+++ b/src/transition.v
@@ -55,8 +55,8 @@ pub fn transition(c TransitionParams) &Transition {
 
 fn (mut t Transition) init(parent Layout) {
 	t.parent = parent
-	gui := parent.get_ui()
-	t.ui = gui
+	u := parent.get_ui()
+	t.ui = u
 }
 
 [manualfree]

--- a/src/window.v
+++ b/src/window.v
@@ -692,8 +692,8 @@ fn on_event(e &gg.Event, mut window Window) {
 	*/
 }
 
-fn window_resize(event gg.Event, gui &UI) {
-	mut window := gui.window
+fn window_resize(event gg.Event, u &UI) {
+	mut window := u.window
 	if !window.resizable {
 		return
 	}
@@ -711,9 +711,9 @@ fn window_resize(event gg.Event, gui &UI) {
 	}
 }
 
-fn window_key_down(event gg.Event, gui &UI) {
+fn window_key_down(event gg.Event, u &UI) {
 	// println('keydown char=$event.char_code')
-	mut window := gui.window
+	mut window := u.window
 	// C.printf(c'g child=%p\n', child)
 	// println('window_keydown $event')
 	e := KeyEvent{
@@ -780,10 +780,10 @@ fn window_key_down(event gg.Event, gui &UI) {
 	*/
 }
 
-fn window_char(event gg.Event, gui &UI) {
+fn window_char(event gg.Event, u &UI) {
 	// println('keychar char=$event.char_code')
 	// println("window_char: $event")
-	window := gui.window
+	window := u.window
 	e := KeyEvent{
 		codepoint: event.char_code
 		mods: unsafe { KeyMod(event.modifiers) }
@@ -796,9 +796,9 @@ fn window_char(event gg.Event, gui &UI) {
 	window.eventbus.publish(events.on_char, window, e)
 }
 
-fn window_mouse_down(event gg.Event, mut gui UI) {
+fn window_mouse_down(event gg.Event, mut u UI) {
 	// println("typ mouse down $event.typ")
-	mut window := gui.window
+	mut window := u.window
 	e := MouseEvent{
 		action: .down
 		x: int(event.mouse_x / window.dpi_scale)
@@ -806,9 +806,9 @@ fn window_mouse_down(event gg.Event, mut gui UI) {
 		button: MouseButton(event.mouse_button)
 		mods: unsafe { KeyMod(event.modifiers) }
 	}
-	gui.keymods = unsafe { KeyMod(event.modifiers) }
+	u.keymods = unsafe { KeyMod(event.modifiers) }
 	if int(event.mouse_button) < 3 {
-		gui.btn_down[int(event.mouse_button)] = true
+		u.btn_down[int(event.mouse_button)] = true
 	}
 	if window.mouse_down_fn != WindowMouseFn(0) { // && action == voidptr(0) {
 		window.mouse_down_fn(window, e)
@@ -831,9 +831,9 @@ fn window_mouse_down(event gg.Event, mut gui UI) {
 	}
 }
 
-fn window_mouse_move(event gg.Event, gui &UI) {
+fn window_mouse_move(event gg.Event, u &UI) {
 	// println("typ mouse move $event.typ")
-	mut window := gui.window
+	mut window := u.window
 	e := MouseMoveEvent{
 		x: event.mouse_x / window.dpi_scale
 		y: event.mouse_y / window.dpi_scale
@@ -857,9 +857,9 @@ fn window_mouse_move(event gg.Event, gui &UI) {
 	window.eventbus.publish(events.on_mouse_move, window, e)
 }
 
-fn window_mouse_up(event gg.Event, mut gui UI) {
+fn window_mouse_up(event gg.Event, mut u UI) {
 	// println("typ mouse up $event.typ")
-	mut window := gui.window
+	mut window := u.window
 	e := MouseEvent{
 		action: .up
 		x: int(event.mouse_x / window.dpi_scale)
@@ -892,14 +892,14 @@ fn window_mouse_up(event gg.Event, mut gui UI) {
 		}
 		drag_child_dropped(mut window)
 	}
-	mut gui_ := unsafe { gui }
-	gui_.keymods = unsafe { KeyMod(0) }
+	mut gui := unsafe { u }
+	gui.keymods = unsafe { KeyMod(0) }
 }
 
 // OBSOLETE see window_click_or_touch_pad
 /*
-fn window_click(event gg.Event, mut gui UI) {
-	window := gui.window
+fn window_click(event gg.Event, mut u UI) {
+	window := u.window
 	// println("typ click $event.typ")
 	e := MouseEvent{
 		action: if event.typ == .mouse_up { MouseAction.up } else { MouseAction.down }
@@ -927,8 +927,8 @@ fn window_click(event gg.Event, mut gui UI) {
 	}
 }*/
 
-fn window_scroll(event gg.Event, gui &UI) {
-	mut window := gui.window
+fn window_scroll(event gg.Event, u &UI) {
+	mut window := u.window
 	// println('title =$window.title')
 	e := ScrollEvent{
 		mouse_x: event.mouse_x / window.dpi_scale
@@ -943,8 +943,8 @@ fn window_scroll(event gg.Event, gui &UI) {
 	window.eventbus.publish(events.on_scroll, window, e)
 }
 
-fn window_touch_down(event gg.Event, gui &UI) {
-	mut window := gui.window
+fn window_touch_down(event gg.Event, u &UI) {
+	mut window := u.window
 	e := MouseEvent{
 		action: .down
 		x: window.touch.start.pos.x
@@ -957,8 +957,8 @@ fn window_touch_down(event gg.Event, gui &UI) {
 	window.eventbus.publish(events.on_touch_down, window, e)
 }
 
-fn window_touch_move(event gg.Event, gui &UI) {
-	window := gui.window
+fn window_touch_move(event gg.Event, u &UI) {
+	window := u.window
 	e := MouseMoveEvent{
 		x: f64(window.touch.move.pos.x)
 		y: f64(window.touch.move.pos.y)
@@ -970,8 +970,8 @@ fn window_touch_move(event gg.Event, gui &UI) {
 	window.eventbus.publish(events.on_touch_move, window, e)
 }
 
-fn window_touch_up(event gg.Event, gui &UI) {
-	window := gui.window
+fn window_touch_up(event gg.Event, u &UI) {
+	window := u.window
 	e := MouseEvent{
 		action: .up
 		x: window.touch.end.pos.x
@@ -983,9 +983,9 @@ fn window_touch_up(event gg.Event, gui &UI) {
 	window.eventbus.publish(events.on_touch_up, window, e)
 }
 
-fn window_click_or_touch_tap(event gg.Event, gui &UI) {
+fn window_click_or_touch_tap(event gg.Event, u &UI) {
 	// println("typ on_tap $event.typ")
-	window := gui.window
+	window := u.window
 	e := MouseEvent{
 		action: MouseAction.up // if event.typ == .mouse_up { MouseAction.up } else { MouseAction.down }
 		x: window.touch.end.pos.x
@@ -1003,14 +1003,14 @@ fn window_click_or_touch_tap(event gg.Event, gui &UI) {
 		window.eventbus.publish(events.on_click, window, e)
 	}
 
-	mut gui_ := unsafe { gui }
+	mut gui := unsafe { u }
 	if int(event.mouse_button) < 3 {
-		gui_.btn_down[int(event.mouse_button)] = false
+		gui.btn_down[int(event.mouse_button)] = false
 	}
 }
 
-fn window_touch_scroll(event gg.Event, gui &UI) {
-	mut window := gui.window
+fn window_touch_scroll(event gg.Event, u &UI) {
+	mut window := u.window
 	// println('title =$window.title')
 	s, m := window.touch.start, window.touch.move
 	adx, ady := m.pos.x - s.pos.x, m.pos.y - s.pos.y
@@ -1027,8 +1027,8 @@ fn window_touch_scroll(event gg.Event, gui &UI) {
 	window.eventbus.publish(events.on_scroll, window, e)
 }
 
-fn window_touch_swipe(event gg.Event, gui &UI) {
-	window := gui.window
+fn window_touch_swipe(event gg.Event, u &UI) {
+	window := u.window
 	e := MouseEvent{
 		action: MouseAction.up // if event.typ == .mouse_up { MouseAction.up } else { MouseAction.down }
 		x: window.touch.end.pos.x
@@ -1045,25 +1045,25 @@ fn window_touch_swipe(event gg.Event, gui &UI) {
 	} else {
 		window.eventbus.publish(events.on_swipe, window, e)
 	}
-	mut gui_ := unsafe { gui }
+	mut gui := unsafe { u }
 	if int(event.mouse_button) < 3 {
-		gui_.btn_down[int(event.mouse_button)] = false
+		gui.btn_down[int(event.mouse_button)] = false
 	}
 }
 
-fn window_click_or_touch_tap_and_swipe(event gg.Event, gui &UI) {
-	window := gui.window
+fn window_click_or_touch_tap_and_swipe(event gg.Event, u &UI) {
+	window := u.window
 	s, e := window.touch.start, window.touch.end
 	adx, ady := math.abs(e.pos.x - s.pos.x), math.abs(e.pos.y - s.pos.y)
 	if math.max(adx, ady) < 10 {
-		window_click_or_touch_tap(event, gui)
+		window_click_or_touch_tap(event, u)
 	} else {
-		window_touch_swipe(event, gui)
+		window_touch_swipe(event, u)
 	}
 }
 
-fn window_files_droped(event gg.Event, mut gui UI) {
-	mut window := gui.window
+fn window_files_droped(event gg.Event, mut u UI) {
+	mut window := u.window
 	e := MouseEvent{
 		action: .down
 		x: int(event.mouse_x / window.dpi_scale)

--- a/src/window.v
+++ b/src/window.v
@@ -692,8 +692,8 @@ fn on_event(e &gg.Event, mut window Window) {
 	*/
 }
 
-fn window_resize(event gg.Event, ui &UI) {
-	mut window := ui.window
+fn window_resize(event gg.Event, gui &UI) {
+	mut window := gui.window
 	if !window.resizable {
 		return
 	}
@@ -711,9 +711,9 @@ fn window_resize(event gg.Event, ui &UI) {
 	}
 }
 
-fn window_key_down(event gg.Event, ui &UI) {
+fn window_key_down(event gg.Event, gui &UI) {
 	// println('keydown char=$event.char_code')
-	mut window := ui.window
+	mut window := gui.window
 	// C.printf(c'g child=%p\n', child)
 	// println('window_keydown $event')
 	e := KeyEvent{
@@ -780,10 +780,10 @@ fn window_key_down(event gg.Event, ui &UI) {
 	*/
 }
 
-fn window_char(event gg.Event, ui &UI) {
+fn window_char(event gg.Event, gui &UI) {
 	// println('keychar char=$event.char_code')
 	// println("window_char: $event")
-	window := ui.window
+	window := gui.window
 	e := KeyEvent{
 		codepoint: event.char_code
 		mods: unsafe { KeyMod(event.modifiers) }
@@ -796,9 +796,9 @@ fn window_char(event gg.Event, ui &UI) {
 	window.eventbus.publish(events.on_char, window, e)
 }
 
-fn window_mouse_down(event gg.Event, mut ui UI) {
+fn window_mouse_down(event gg.Event, mut gui UI) {
 	// println("typ mouse down $event.typ")
-	mut window := ui.window
+	mut window := gui.window
 	e := MouseEvent{
 		action: .down
 		x: int(event.mouse_x / window.dpi_scale)
@@ -806,9 +806,9 @@ fn window_mouse_down(event gg.Event, mut ui UI) {
 		button: MouseButton(event.mouse_button)
 		mods: unsafe { KeyMod(event.modifiers) }
 	}
-	ui.keymods = unsafe { KeyMod(event.modifiers) }
+	gui.keymods = unsafe { KeyMod(event.modifiers) }
 	if int(event.mouse_button) < 3 {
-		ui.btn_down[int(event.mouse_button)] = true
+		gui.btn_down[int(event.mouse_button)] = true
 	}
 	if window.mouse_down_fn != WindowMouseFn(0) { // && action == voidptr(0) {
 		window.mouse_down_fn(window, e)
@@ -831,9 +831,9 @@ fn window_mouse_down(event gg.Event, mut ui UI) {
 	}
 }
 
-fn window_mouse_move(event gg.Event, ui &UI) {
+fn window_mouse_move(event gg.Event, gui &UI) {
 	// println("typ mouse move $event.typ")
-	mut window := ui.window
+	mut window := gui.window
 	e := MouseMoveEvent{
 		x: event.mouse_x / window.dpi_scale
 		y: event.mouse_y / window.dpi_scale
@@ -857,9 +857,9 @@ fn window_mouse_move(event gg.Event, ui &UI) {
 	window.eventbus.publish(events.on_mouse_move, window, e)
 }
 
-fn window_mouse_up(event gg.Event, mut ui UI) {
+fn window_mouse_up(event gg.Event, mut gui UI) {
 	// println("typ mouse up $event.typ")
-	mut window := ui.window
+	mut window := gui.window
 	e := MouseEvent{
 		action: .up
 		x: int(event.mouse_x / window.dpi_scale)
@@ -892,14 +892,14 @@ fn window_mouse_up(event gg.Event, mut ui UI) {
 		}
 		drag_child_dropped(mut window)
 	}
-	mut gui := unsafe { ui }
-	gui.keymods = unsafe { KeyMod(0) }
+	mut gui_ := unsafe { gui }
+	gui_.keymods = unsafe { KeyMod(0) }
 }
 
 // OBSOLETE see window_click_or_touch_pad
 /*
-fn window_click(event gg.Event, mut ui UI) {
-	window := ui.window
+fn window_click(event gg.Event, mut gui UI) {
+	window := gui.window
 	// println("typ click $event.typ")
 	e := MouseEvent{
 		action: if event.typ == .mouse_up { MouseAction.up } else { MouseAction.down }
@@ -927,8 +927,8 @@ fn window_click(event gg.Event, mut ui UI) {
 	}
 }*/
 
-fn window_scroll(event gg.Event, ui &UI) {
-	mut window := ui.window
+fn window_scroll(event gg.Event, gui &UI) {
+	mut window := gui.window
 	// println('title =$window.title')
 	e := ScrollEvent{
 		mouse_x: event.mouse_x / window.dpi_scale
@@ -943,8 +943,8 @@ fn window_scroll(event gg.Event, ui &UI) {
 	window.eventbus.publish(events.on_scroll, window, e)
 }
 
-fn window_touch_down(event gg.Event, ui &UI) {
-	mut window := ui.window
+fn window_touch_down(event gg.Event, gui &UI) {
+	mut window := gui.window
 	e := MouseEvent{
 		action: .down
 		x: window.touch.start.pos.x
@@ -957,8 +957,8 @@ fn window_touch_down(event gg.Event, ui &UI) {
 	window.eventbus.publish(events.on_touch_down, window, e)
 }
 
-fn window_touch_move(event gg.Event, ui &UI) {
-	window := ui.window
+fn window_touch_move(event gg.Event, gui &UI) {
+	window := gui.window
 	e := MouseMoveEvent{
 		x: f64(window.touch.move.pos.x)
 		y: f64(window.touch.move.pos.y)
@@ -970,8 +970,8 @@ fn window_touch_move(event gg.Event, ui &UI) {
 	window.eventbus.publish(events.on_touch_move, window, e)
 }
 
-fn window_touch_up(event gg.Event, ui &UI) {
-	window := ui.window
+fn window_touch_up(event gg.Event, gui &UI) {
+	window := gui.window
 	e := MouseEvent{
 		action: .up
 		x: window.touch.end.pos.x
@@ -983,9 +983,9 @@ fn window_touch_up(event gg.Event, ui &UI) {
 	window.eventbus.publish(events.on_touch_up, window, e)
 }
 
-fn window_click_or_touch_tap(event gg.Event, ui &UI) {
+fn window_click_or_touch_tap(event gg.Event, gui &UI) {
 	// println("typ on_tap $event.typ")
-	window := ui.window
+	window := gui.window
 	e := MouseEvent{
 		action: MouseAction.up // if event.typ == .mouse_up { MouseAction.up } else { MouseAction.down }
 		x: window.touch.end.pos.x
@@ -1003,14 +1003,14 @@ fn window_click_or_touch_tap(event gg.Event, ui &UI) {
 		window.eventbus.publish(events.on_click, window, e)
 	}
 
-	mut gui := unsafe { ui }
+	mut gui_ := unsafe { gui }
 	if int(event.mouse_button) < 3 {
-		gui.btn_down[int(event.mouse_button)] = false
+		gui_.btn_down[int(event.mouse_button)] = false
 	}
 }
 
-fn window_touch_scroll(event gg.Event, ui &UI) {
-	mut window := ui.window
+fn window_touch_scroll(event gg.Event, gui &UI) {
+	mut window := gui.window
 	// println('title =$window.title')
 	s, m := window.touch.start, window.touch.move
 	adx, ady := m.pos.x - s.pos.x, m.pos.y - s.pos.y
@@ -1027,8 +1027,8 @@ fn window_touch_scroll(event gg.Event, ui &UI) {
 	window.eventbus.publish(events.on_scroll, window, e)
 }
 
-fn window_touch_swipe(event gg.Event, ui &UI) {
-	window := ui.window
+fn window_touch_swipe(event gg.Event, gui &UI) {
+	window := gui.window
 	e := MouseEvent{
 		action: MouseAction.up // if event.typ == .mouse_up { MouseAction.up } else { MouseAction.down }
 		x: window.touch.end.pos.x
@@ -1045,25 +1045,25 @@ fn window_touch_swipe(event gg.Event, ui &UI) {
 	} else {
 		window.eventbus.publish(events.on_swipe, window, e)
 	}
-	mut gui := unsafe { ui }
+	mut gui_ := unsafe { gui }
 	if int(event.mouse_button) < 3 {
-		gui.btn_down[int(event.mouse_button)] = false
+		gui_.btn_down[int(event.mouse_button)] = false
 	}
 }
 
-fn window_click_or_touch_tap_and_swipe(event gg.Event, ui &UI) {
-	window := ui.window
+fn window_click_or_touch_tap_and_swipe(event gg.Event, gui &UI) {
+	window := gui.window
 	s, e := window.touch.start, window.touch.end
 	adx, ady := math.abs(e.pos.x - s.pos.x), math.abs(e.pos.y - s.pos.y)
 	if math.max(adx, ady) < 10 {
-		window_click_or_touch_tap(event, ui)
+		window_click_or_touch_tap(event, gui)
 	} else {
-		window_touch_swipe(event, ui)
+		window_touch_swipe(event, gui)
 	}
 }
 
-fn window_files_droped(event gg.Event, mut ui UI) {
-	mut window := ui.window
+fn window_files_droped(event gg.Event, mut gui UI) {
+	mut window := gui.window
 	e := MouseEvent{
 		action: .down
 		x: int(event.mouse_x / window.dpi_scale)


### PR DESCRIPTION
This PR renames variables and parameters to prevent module name shadowing. Related to: https://github.com/vlang/v/pull/18118

I mostly opted for `gui`. On master current handlings to not shadow the `ui` module are `gui` and `u`. Please let me know what you prefer, some quick changes are no work. 

https://github.com/vlang/ui/blob/417db89c2b771601c88404399cc144a01e8716e8/src/ui.v#L66

https://github.com/vlang/ui/blob/417db89c2b771601c88404399cc144a01e8716e8/src/tool_text_style.v#L128