### PR TITLE
fix: Stack widget should have lower z-index than child with the lowest z-index

### DIFF
--- a/src/stack.v
+++ b/src/stack.v
@@ -1111,7 +1111,7 @@ pub fn (mut s Stack) set_drawing_children() {
 			}
 		}
 		// println("z_index: ${child.type_name()} $child.z_index")
-		if child.z_index > s.z_index {
+		if s.z_index > child.z_index {
 			s.z_index = child.z_index - 1
 		}
 	}

--- a/src/textbox.v
+++ b/src/textbox.v
@@ -390,12 +390,14 @@ pub fn (mut tb TextBox) draw_device(mut d DrawDevice) {
 		// Placeholder
 		if text == '' && placeholder != '' {
 			dtw.draw_device_styled_text(d, tb.x + ui.textbox_padding_x, text_y, placeholder,
-				color: gx.gray)
+				color: gx.gray
+			)
 			// Native text rendering
 			$if macos {
 				if tb.ui.gg.native_rendering {
 					tb.ui.gg.draw_text(tb.x + ui.textbox_padding_x, text_y, placeholder,
-						color: gx.gray)
+						color: gx.gray
+					)
 				}
 			}
 		}

--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -321,7 +321,6 @@ fn (mut tv TextView) draw_device_selection(d DrawDevice) {
 
 fn (tv &TextView) draw_device_line_number(d DrawDevice, i int, y int) {
 	tv.draw_device_styled_text(d, tv.tb.x + ui.textview_margin, y, (tv.tlv.from_j + i + 1).str(),
-		
 		color: gx.gray
 	)
 }


### PR DESCRIPTION
Currently, the Stack (column/row) calculates it's z-index based on children's z-index. Stack will have `z-index = child_with_biggest_z_index - 1`, which is wrong since a Stack can have children with different z-index and a Stack must have the lowest z-index to not cover children.

As an example, I have the following UI setup

```v
	app.window = ui.window(
		width: 600
		height: 600
		title: 'Polygon Editor'
		children: [
			ui.column(
				id: 'test'
				children: [
					ui.menubar(
						height: 30
						z_index: 2
						items: [
							ui.menuitem(
								id: 'file_menu_button'
								text: 'File...'
								action: open_file_menu
							),
						]
					),
					ui.menu(
						id: 'file_menu_dropdown'
						z_index: 2
					),
					gg_canvaslayout(
						app: viewport_app
						z_index: 1
					),
				]
			),
		]
	)
```

Both `menubar` and `menu` widgets must be above `gg_canvaslayout`, and `gg_canvaslayout` must be above `column` widget. So in this case `column` widget must have z-index `0`

This PR fixes current behavior, so Stack widget will have z-index = `child_with_lowest_z_index - 1`