### PR TITLE
Add z index parameter to `GGComponentParams`

### DIFF
--- a/component/gg_app.v
+++ b/component/gg_app.v
@@ -14,8 +14,9 @@ pub mut:
 
 [params]
 pub struct GGComponentParams {
-	id  string = 'gg_app'
-	app ui.GGApplication
+	id      string = 'gg_app'
+	app     ui.GGApplication
+	z_index int
 }
 
 pub fn gg_canvaslayout(p GGComponentParams) &ui.CanvasLayout {
@@ -25,6 +26,7 @@ pub fn gg_canvaslayout(p GGComponentParams) &ui.CanvasLayout {
 		on_draw: gg_draw
 		on_delegate: gg_on_delegate
 		on_bounding_change: gg_on_bounding_change
+		z_index: p.z_index
 	)
 	mut ggc := &GGComponent{
 		id: p.id

--- a/src/textbox.v
+++ b/src/textbox.v
@@ -390,12 +390,14 @@ pub fn (mut tb TextBox) draw_device(mut d DrawDevice) {
 		// Placeholder
 		if text == '' && placeholder != '' {
 			dtw.draw_device_styled_text(d, tb.x + ui.textbox_padding_x, text_y, placeholder,
-				color: gx.gray)
+				color: gx.gray
+			)
 			// Native text rendering
 			$if macos {
 				if tb.ui.gg.native_rendering {
 					tb.ui.gg.draw_text(tb.x + ui.textbox_padding_x, text_y, placeholder,
-						color: gx.gray)
+						color: gx.gray
+					)
 				}
 			}
 		}

--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -321,7 +321,6 @@ fn (mut tv TextView) draw_device_selection(d DrawDevice) {
 
 fn (tv &TextView) draw_device_line_number(d DrawDevice, i int, y int) {
 	tv.draw_device_styled_text(d, tv.tb.x + ui.textview_margin, y, (tv.tlv.from_j + i + 1).str(),
-		
 		color: gx.gray
 	)
 }


### PR DESCRIPTION
This PR adds `z-index` field to `GGComponentParams` structure, and uses this field when creating `CanvasLayout` in `gg_canvaslayout` function. 