### PR TITLE
fix: `menu` size doesn't update when items added dynamically

### DIFF
--- a/src/menu.v
+++ b/src/menu.v
@@ -417,6 +417,7 @@ fn (mut m Menu) draw_device(mut d DrawDevice) {
 
 pub fn (mut m Menu) add_item(p MenuItemParams) {
 	m.items << menuitem(p)
+	m.update_size()
 }
 
 pub fn (mut m Menu) set_visible(state bool) {

--- a/src/textbox.v
+++ b/src/textbox.v
@@ -390,12 +390,14 @@ pub fn (mut tb TextBox) draw_device(mut d DrawDevice) {
 		// Placeholder
 		if text == '' && placeholder != '' {
 			dtw.draw_device_styled_text(d, tb.x + ui.textbox_padding_x, text_y, placeholder,
-				color: gx.gray)
+				color: gx.gray
+			)
 			// Native text rendering
 			$if macos {
 				if tb.ui.gg.native_rendering {
 					tb.ui.gg.draw_text(tb.x + ui.textbox_padding_x, text_y, placeholder,
-						color: gx.gray)
+						color: gx.gray
+					)
 				}
 			}
 		}

--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -321,7 +321,6 @@ fn (mut tv TextView) draw_device_selection(d DrawDevice) {
 
 fn (tv &TextView) draw_device_line_number(d DrawDevice, i int, y int) {
 	tv.draw_device_styled_text(d, tv.tb.x + ui.textview_margin, y, (tv.tlv.from_j + i + 1).str(),
-		
 		color: gx.gray
 	)
 }


### PR DESCRIPTION
This PR introduces a potentially dirty fix. When items are added to the menu dynamically, them menu size wasn't updated. This PR change - is to call `update_size` function from `add_item` function after item was added