### PR TITLE
Implement `get_items_count` menu function

### DIFF
--- a/src/menu.v
+++ b/src/menu.v
@@ -419,6 +419,10 @@ pub fn (mut m Menu) add_item(p MenuItemParams) {
 	m.items << menuitem(p)
 }
 
+pub fn (mut m Menu) get_items_count() int {
+	return m.items.len
+}
+
 pub fn (mut m Menu) set_visible(state bool) {
 	m.hidden = !state
 }

--- a/src/textbox.v
+++ b/src/textbox.v
@@ -390,12 +390,14 @@ pub fn (mut tb TextBox) draw_device(mut d DrawDevice) {
 		// Placeholder
 		if text == '' && placeholder != '' {
 			dtw.draw_device_styled_text(d, tb.x + ui.textbox_padding_x, text_y, placeholder,
-				color: gx.gray)
+				color: gx.gray
+			)
 			// Native text rendering
 			$if macos {
 				if tb.ui.gg.native_rendering {
 					tb.ui.gg.draw_text(tb.x + ui.textbox_padding_x, text_y, placeholder,
-						color: gx.gray)
+						color: gx.gray
+					)
 				}
 			}
 		}

--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -321,7 +321,6 @@ fn (mut tv TextView) draw_device_selection(d DrawDevice) {
 
 fn (tv &TextView) draw_device_line_number(d DrawDevice, i int, y int) {
 	tv.draw_device_styled_text(d, tv.tb.x + ui.textview_margin, y, (tv.tlv.from_j + i + 1).str(),
-		
 		color: gx.gray
 	)
 }


### PR DESCRIPTION
This PR implements `get_items_count` public function. This function is needed when UI logic depends on the current count of items in the menu.