### PR TITLE
fix: handling of delegated events

### DIFF
--- a/src/textbox.v
+++ b/src/textbox.v
@@ -390,12 +390,14 @@ pub fn (mut tb TextBox) draw_device(mut d DrawDevice) {
 		// Placeholder
 		if text == '' && placeholder != '' {
 			dtw.draw_device_styled_text(d, tb.x + ui.textbox_padding_x, text_y, placeholder,
-				color: gx.gray)
+				color: gx.gray
+			)
 			// Native text rendering
 			$if macos {
 				if tb.ui.gg.native_rendering {
 					tb.ui.gg.draw_text(tb.x + ui.textbox_padding_x, text_y, placeholder,
-						color: gx.gray)
+						color: gx.gray
+					)
 				}
 			}
 		}

--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -321,7 +321,6 @@ fn (mut tv TextView) draw_device_selection(d DrawDevice) {
 
 fn (tv &TextView) draw_device_line_number(d DrawDevice, i int, y int) {
 	tv.draw_device_styled_text(d, tv.tb.x + ui.textview_margin, y, (tv.tlv.from_j + i + 1).str(),
-		
 		color: gx.gray
 	)
 }

--- a/src/window.v
+++ b/src/window.v
@@ -533,7 +533,7 @@ fn on_event(e &gg.Event, mut window Window) {
 
 		for mut widget in window.evt_mngr.receivers[events.on_delegate] {
 			if widget.point_inside(x, y) {
-				highest_selected_delegated_widget = widget
+				highest_selected_delegated_widget = *widget
 			}
 		}
 


### PR DESCRIPTION
This PR introduces a change to the handling of delegated events when there are selected widgets with higher z-index than delegated widgets. This is the case when using both menubar with submenus and gg canvas - previously, events will be always redirected to canvas even if a higher menu button was selected.