### PR TITLE
Address breaking changes introduced in #19015 in V repo

### DIFF
--- a/src/picture.v
+++ b/src/picture.v
@@ -95,7 +95,7 @@ fn (mut pic Picture) init(parent Layout) {
 		if !pic.use_cache && pic.path in u.resource_cache {
 			pic.image = u.resource_cache[pic.path]
 		} else if mut pic.ui.dd is DrawDeviceContext {
-			dd := pic.ui.dd
+			mut dd := pic.ui.dd
 			if img := dd.create_image(pic.path) {
 				pic.image = img
 				u.resource_cache[pic.path] = pic.image


### PR DESCRIPTION
https://github.com/vlang/v/pull/19015 made `gg.Context` mutable for `create_image` method. This causes CI checks in V repo to fail for this PR.

This PR introduces "non-invasive" fix to V UI to make CI on V repo pass