### PR TITLE
examples: update `build_examples.vsh`

### DIFF
--- a/examples/build_examples.vsh
+++ b/examples/build_examples.vsh
@@ -1,19 +1,22 @@
+#!/usr/bin/env -S v
+
 fn println_one_of_many(msg string, entry_idx int, entries_len int) {
 	eprintln('${entry_idx + 1:2}/${entries_len:-2} ${msg}')
 }
 
-examples_dir := resource_abs_path('.')
+examples_dir := join_path(@VMODROOT, 'examples')
 mut all_entries := walk_ext(examples_dir, '.v')
 all_entries.sort()
 mut entries := []string{}
+
 for entry in all_entries {
-	fname := file_name(entry)
 	if entry.contains('textbox_input') {
 		eprintln('skipping ${entry}, part of the folder based `textbox_input` example')
 		continue
 	}
-	if fname == 'webview.v' {
-		$if !macos {
+	$if !macos {
+		fname := file_name(entry)
+		if fname == 'webview.v' {
 			eprintln('skipping ${entry} on !macos')
 			continue
 		}
@@ -24,16 +27,18 @@ entries << join_path(examples_dir, 'textbox_input')
 
 mut err := 0
 mut failures := []string{}
+chdir(examples_dir)!
 for entry_idx, entry in entries {
 	cmd := 'v -no-parallel ${entry}'
 	println_one_of_many('compile with: ${cmd}', entry_idx, entries.len)
-	ret := system(cmd)
-	if ret != 0 {
+	ret := execute(cmd)
+	if ret.exit_code != 0 {
 		err++
 		eprintln('>>> FAILURE')
 		failures << cmd
 	}
 }
+
 if err > 0 {
 	err_count := if err == 1 { '1 error' } else { '${err} errors' }
 	for f in failures {


### PR DESCRIPTION
- adds shebang to allow to run int a script without prefix
- makes execution of the script directory independent
- execute over system as it currently enables to Ctrl-c out of the scripts execution