### PR TITLE
chore: update gitattributes to recognize V language for `.vsh` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+* text=auto eol=lf
+*.bat eol=crlf
+
+**/*.v linguist-language=V
+**/*.vv linguist-language=V
+**/*.vsh linguist-language=V
+**/v.mod linguist-language=V
+
 webview/windows/* linguist-vendored
-*.v linguist-language=V
-*.mod linguist-language=V


### PR DESCRIPTION
should fix recognising .vsh as glsl