### PR TITLE
chore: update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,18 +6,13 @@
 *.ilk
 *.pdb
 
-examples/**/*
-!examples/**/*.v
-!examples/**/*.vab
-!examples/android
-!examples/assets
-!examples/layout
-!examples/component
-!examples/apps
-!examples/wm
-fmt_verify_all
+# All sub-level build binaries
+*/**/*
+!*/**/*/
+!*/**/*.*
 
-# Ignore editor files
+# Common editor/system specific metadata
+.DS_Store
 .idea
 .vscode
 *.code-workspace
@@ -32,7 +27,4 @@ screenshot*.png
 screenshot*.svg
 
 # To develop examples inside ui folder
-examples/modules
 devel
-
-.git/


### PR DESCRIPTION
The current ignore config corrupts the results of some search tools that are influenced by the gitignore config in a project as it ignores some project files.

This simple change adds an ignore / unignore pattern that ignores more files should be ignored, while preventing files from being ignored that should not-be ignored.