### PR TITLE
use the builtin consts for `max_i32` and `min_i32`, instead of the constants defined in `math`

### DIFF
--- a/src/draw_device_bitmap.v
+++ b/src/draw_device_bitmap.v
@@ -3,7 +3,6 @@ module ui
 import gx
 import gg
 import ui.libvg
-import math
 
 struct DrawDeviceBitmap {
 	id string = 'dd_bitmap'
@@ -152,7 +151,7 @@ pub fn (d &DrawDeviceBitmap) set_clipping(rect Rect) {
 // TODO: documentation
 pub fn (d &DrawDeviceBitmap) get_clipping() Rect {
 	// TODO: implement
-	return Rect{0, 0, int(math.max_i32), int(math.max_i32)}
+	return Rect{0, 0, int(max_i32), int(max_i32)}
 }
 
 // TODO: documentation

--- a/src/draw_device_print.v
+++ b/src/draw_device_print.v
@@ -2,7 +2,6 @@ module ui
 
 import gx
 import gg
-import math
 
 struct DrawDevicePrint {
 	id       string = 'dd_print'
@@ -83,7 +82,7 @@ pub fn (d &DrawDevicePrint) set_clipping(rect Rect) {
 // TODO: documentation
 pub fn (d &DrawDevicePrint) get_clipping() Rect {
 	// TODO: implement
-	return Rect{0, 0, int(math.max_i32), int(math.max_i32)}
+	return Rect{0, 0, int(max_i32), int(max_i32)}
 }
 
 // TODO: documentation

--- a/src/draw_device_svg.v
+++ b/src/draw_device_svg.v
@@ -135,7 +135,7 @@ pub fn (d &DrawDeviceSVG) set_clipping(rect Rect) {
 // TODO: documentation
 pub fn (d &DrawDeviceSVG) get_clipping() Rect {
 	// TODO: implement
-	return Rect{0, 0, int(math.max_i32), int(math.max_i32)}
+	return Rect{0, 0, int(max_i32), int(max_i32)}
 }
 
 // TODO: documentation

--- a/src/draw_device_svg.v
+++ b/src/draw_device_svg.v
@@ -3,7 +3,6 @@ module ui
 import gx
 import gg
 import ui.libvg
-import math
 
 struct DrawDeviceSVG {
 mut:


### PR DESCRIPTION
This PR needed to make tests pass in vlang/v#19809