### PR TITLE
Fix tabs titles

### DIFF
--- a/component/tabs.v
+++ b/component/tabs.v
@@ -55,9 +55,9 @@ pub fn tabs_stack(c TabsParams) &ui.Stack {
 				ui.row(
 					id: tab_id(c.id, i) + '_row'
 					children: [
-						ui.label(id: tab_id(c.id, i) + '_label', text: tab)
+						ui.label(id: tab_id(c.id, i) + '_label', text: tab),
 					]
-				)
+				),
 			]
 		)
 	}
@@ -270,4 +270,3 @@ fn (tabs &TabsComponent) update_pos(win &ui.Window) {
 		c.set_child_relative_pos(row_id, dx, dy)
 	}
 }
-

--- a/component/tabs.v
+++ b/component/tabs.v
@@ -52,7 +52,12 @@ pub fn tabs_stack(c TabsParams) &ui.Stack {
 			// bg_color: gx.white
 			on_key_down: tab_key_down
 			children: [
-				ui.label(id: tab_id(c.id, i) + '_label', text: tab),
+				ui.row(
+					id: tab_id(c.id, i) + '_row'
+					children: [
+						ui.label(id: tab_id(c.id, i) + '_label', text: tab)
+					]
+				)
 			]
 		)
 	}
@@ -260,7 +265,9 @@ fn (tabs &TabsComponent) update_pos(win &ui.Window) {
 		// println("$dx, $dy $lab.x $lab.y")
 		lab.set_pos(dx, dy)
 		// println("$dx, $dy $lab.x $lab.y")
+		row_id := tab_id(tabs.id, i) + '_row'
 		mut c := win.get_or_panic[ui.CanvasLayout](tab_id(tabs.id, i))
-		c.set_child_relative_pos(lab_id, dx, dy)
+		c.set_child_relative_pos(row_id, dx, dy)
 	}
 }
+


### PR DESCRIPTION
Wrapped labels inside a `row` to position theses instead of labels.

For some reasons the `.set_pos()` method is not working on labels directly so the trick is to set position of a parent, that's why we wrap labels into `row` (we could also use `column`)