### PR TITLE
Add minimal size to scrollbar thumb

### DIFF
--- a/component/tabs.v
+++ b/component/tabs.v
@@ -55,9 +55,9 @@ pub fn tabs_stack(c TabsParams) &ui.Stack {
 				ui.row(
 					id: tab_id(c.id, i) + '_row'
 					children: [
-						ui.label(id: tab_id(c.id, i) + '_label', text: tab)
+						ui.label(id: tab_id(c.id, i) + '_label', text: tab),
 					]
-				)
+				),
 			]
 		)
 	}
@@ -270,4 +270,3 @@ fn (tabs &TabsComponent) update_pos(win &ui.Window) {
 		c.set_child_relative_pos(row_id, dx, dy)
 	}
 }
-

--- a/component/tabs.v
+++ b/component/tabs.v
@@ -52,7 +52,12 @@ pub fn tabs_stack(c TabsParams) &ui.Stack {
 			// bg_color: gx.white
 			on_key_down: tab_key_down
 			children: [
-				ui.label(id: tab_id(c.id, i) + '_label', text: tab),
+				ui.row(
+					id: tab_id(c.id, i) + '_row'
+					children: [
+						ui.label(id: tab_id(c.id, i) + '_label', text: tab)
+					]
+				)
 			]
 		)
 	}
@@ -260,7 +265,9 @@ fn (tabs &TabsComponent) update_pos(win &ui.Window) {
 		// println("$dx, $dy $lab.x $lab.y")
 		lab.set_pos(dx, dy)
 		// println("$dx, $dy $lab.x $lab.y")
+		row_id := tab_id(tabs.id, i) + '_row'
 		mut c := win.get_or_panic[ui.CanvasLayout](tab_id(tabs.id, i))
-		c.set_child_relative_pos(lab_id, dx, dy)
+		c.set_child_relative_pos(row_id, dx, dy)
 	}
 }
+

--- a/src/interface_scrollable.v
+++ b/src/interface_scrollable.v
@@ -1,12 +1,14 @@
 module ui
 
 import gx
+import math { max }
 
 // ScrollView exists only when attached to Widget
 // Is it not a widget but attached to a widget.
 // A ScrollableWidget would have a field scrollview
 
 pub const scrollbar_size = 10
+pub const scrollbar_thumb_size = 16
 pub const scroolbar_thumb_color = gx.rgb(87, 153, 245)
 pub const scrollbar_background_color = gx.rgb(219, 219, 219)
 pub const scrollbar_button_color = gx.rgb(150, 150, 150)
@@ -564,7 +566,7 @@ fn (mut sv ScrollView) update() {
 	if sv.active_x {
 		sv.sb_w = sv.width - ui.scrollbar_size
 		sv.btn_w = if sv.width < sv.adj_width {
-			int(f32(sv.width) / f32(sv.adj_width) * f32(sv.sb_w))
+			max(int(f32(sv.width) / f32(sv.adj_width) * f32(sv.sb_w)), ui.scrollbar_thumb_size)
 		} else {
 			sv.sb_w
 		}
@@ -573,7 +575,7 @@ fn (mut sv ScrollView) update() {
 		sv.sb_h = sv.height - ui.scrollbar_size
 		sv.btn_h = if sv.height < sv.adj_height {
 			// println("update: sv.sb_h=$sv.sb_h sv.btn_h = int(${f32(sv.height)} / ${f32(sv.adj_height)} * ${f32(sv.sb_h)} = $sv.btn_h")
-			int(f64(sv.height) / f64(sv.adj_height) * f64(sv.sb_h))
+			max(int(f64(sv.height) / f64(sv.adj_height) * f64(sv.sb_h)), ui.scrollbar_thumb_size)
 		} else {
 			sv.sb_h
 		}


### PR DESCRIPTION
I noticed that with a big element the scrollbar size becomes so small we can't see it anymore
![image](https://github.com/vlang/ui/assets/97396830/2adbdf6a-7bc3-4923-ab8e-810709d9b51f)

Changing a few lines fix this by using the max function and a const min size for the scroll thumb