### PR TITLE
Better multiline textbox cursor movement using the keyboard

### DIFF
--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -402,34 +402,6 @@ fn (mut tv TextView) delete_prev(count int) {
 	tv.update_lines()
 }
 
-fn (mut tv TextView) delete_prev_word() {
-	if tv.cursor_pos <= 0 {
-		tv.cursor_pos = 0
-		return
-	}
-	mut ustr := tv.text.runes()
-	// Delete until previous whitespace
-	// TODO!!!!
-	// mut i := tv.cursor_pos
-	// for {
-	// 	if i > 0 {
-	// 		i--
-	// 	}
-	// 	if text[i].is_space() || i == 0 {
-	// 		// unsafe { *tb.text = u[..i) + u.right(tb.cursor_pos_i]}
-	// 		break
-	// 	}
-	// }
-	// tb.cursor_pos_i = i
-	tv.cursor_pos--
-	ustr.delete(tv.cursor_pos)
-	unsafe {
-		*tv.text = ustr.string()
-	}
-	tv.refresh_visible_lines()
-	tv.update_lines()
-}
-
 fn (mut tv TextView) delete_selection() {
 	// tv.info()
 	if tv.sel_start > tv.sel_end {

--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -353,7 +353,7 @@ fn (mut tv TextView) get_word_bounds() (int, int) {
 
 	// find the start of the word
 	start_search: for start > 0 {
-		for sc in word_separator {
+		for sc in ui.word_separator {
 			if ustr[start - 1] == sc {
 				break start_search
 			}
@@ -363,7 +363,7 @@ fn (mut tv TextView) get_word_bounds() (int, int) {
 
 	// find the end of the word
 	end_search: for end < ustr.len {
-		for sc in word_separator {
+		for sc in ui.word_separator {
 			if ustr[end] == sc {
 				break end_search
 			}

--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -340,6 +340,9 @@ fn (mut tv TextView) insert(s string) {
 
 fn (mut tv TextView) delete_cur_char() {
 	mut ustr := tv.text.runes()
+	if tv.cursor_pos >= ustr.len {
+		return
+	}
 	ustr.delete(tv.cursor_pos)
 	unsafe {
 		*tv.text = ustr.string()


### PR DESCRIPTION
Greatly improved the cursor movement using the keyboard in multiline textboxes.
Support for:
 - quickly jumping over words (ctrl + direction)
 - quickly selecting words (ctrl + shift + direction)
 - deleting entire words using the delete key (ctrl + delete)

This also fixes a crash when pressing delete at the end of the text.