### PR TITLE
UI: change test condition of pic.use_cache to test for true

### DIFF
--- a/src/picture.v
+++ b/src/picture.v
@@ -93,7 +93,7 @@ fn (mut pic Picture) init(parent Layout) {
 		if !os.exists(pic.path) {
 			eprintln('V UI: picture file "${pic.path}" not found')
 		}
-		if !pic.use_cache && pic.path in u.resource_cache {
+		if pic.use_cache && pic.path in u.resource_cache {
 			pic.image = unsafe { u.resource_cache[pic.path] }
 		} else if mut pic.ui.dd is DrawDeviceContext {
 			mut dd := pic.ui.dd


### PR DESCRIPTION
This pull request corrects the condition that tests if the picture widget should use the resource cache to store images.

Not using the cache will result in sokol exhausting its sampler pool after many images are loaded. Once exhausted, sokol emits the following message:
```
sokol_gfx.h, line: 17257, message: SAMPLER_POOL_EXHAUSTED: sampler pool exhausted
```
After several of these message are emitted, sokol faults.