### PR TITLE
UI: Add method to Picture widget to selectively remove images from cache

### DIFF
--- a/src/picture.v
+++ b/src/picture.v
@@ -215,3 +215,7 @@ fn (pic &Picture) drag_type() string {
 fn (pic &Picture) drag_bounds() gg.Rect {
 	return gg.Rect{pic.x + pic.offset_x, pic.y + pic.offset_y, pic.width, pic.height}
 }
+
+pub fn (mut pic Picture) remove_from_cache(path string) {
+	pic.ui.resource_cache.delete(path)
+}


### PR DESCRIPTION
Adds a method to remove images in the resource cache that the Picture widget uses to cache images.

This is needed for long running apps that load many images and then later discard them. Overtime, these cached images causes the memory footprint of the host app to increase.