### PR TITLE
fix: update backspace checks to support both x11 and wayland

### DIFF
--- a/src/textbox.v
+++ b/src/textbox.v
@@ -764,7 +764,7 @@ fn tb_char(mut tb TextBox, e &KeyEvent, window &Window) {
 		}
 		s := utf32_to_str(e.codepoint)
 		// println("tb_char: $s $e.codepoint $e.mods")
-		if int(e.codepoint) !in [0, 9, 13, 27, 127] && e.mods !in [.ctrl, .super] { // skip enter and escape // && e.key !in [.enter, .escape] {
+		if e.codepoint >= 32 && e.codepoint != 127 && e.mods !in [.ctrl, .super] { // skip control chars, del, enter, escape, backspace etc.
 			if tb.read_only {
 				return
 			}

--- a/src/textbox_textview.v
+++ b/src/textbox_textview.v
@@ -564,7 +564,7 @@ fn (mut tv TextView) key_char(e &KeyEvent) {
 	// println('tv key_down $e <$e.key> ${int(e.codepoint)} <$s>')
 	// wui := tv.tb.ui
 	// println('${wui.dd.pressed_keys_edge[int(Key.left_control)]}')
-	if int(e.codepoint) !in [0, 9, 13, 27, 127] && e.mods !in [.ctrl, .super] {
+	if e.codepoint >= 32 && e.codepoint != 127 && e.mods !in [.ctrl, .super] { // skip control chars, del, enter, escape, backspace etc.
 		if tv.tb.read_only {
 			return
 		}


### PR DESCRIPTION
Related to https://github.com/vlang/v/pull/26706, no changes are needed in gui but backspacing was causing issues here.

Backspace was inserting this:
<img width="174" height="70" alt="image" src="https://github.com/user-attachments/assets/a383c828-f165-4a41-af8c-c19089eac979" />
<img width="136" height="58" alt="image" src="https://github.com/user-attachments/assets/09b81c4c-c90c-492d-a24e-17349e3f4daf" />
