### PR TITLE
fix: suppress V compiler errors for unused params and mutable interface casts

### DIFF
--- a/apps/users/users.v
+++ b/apps/users/users.v
@@ -221,7 +221,7 @@ fn (mut app AppUI) btn_add_click(b &Button) {
 
 }
 */
-fn (mut app AppUI) btn_add_click(b &ui.Button) {
+fn (mut app AppUI) btn_add_click(_ &ui.Button) {
 	// println('nr users=$app.users.len')
 	// ui.notify('user', 'done')
 	// app.window.set_cursor(.hand)

--- a/component/accordion.v
+++ b/component/accordion.v
@@ -97,7 +97,7 @@ fn accordion_draw(mut d ui.DrawDevice, c &ui.CanvasLayout) {
 	c.draw_device_styled_text(d, 16, 4, acc.titles[c.id], color: acc.text_color, size: acc.text_size)
 }
 
-fn accordion_click(c &ui.CanvasLayout, e ui.MouseEvent) {
+fn accordion_click(c &ui.CanvasLayout, _ ui.MouseEvent) {
 	mut acc := accordion_component(c)
 	// println("accordion clicked $c.id")
 	acc.selected[c.id] = !acc.selected[c.id]

--- a/component/alpha.v
+++ b/component/alpha.v
@@ -106,7 +106,7 @@ fn alpha_on_value_changed(slider &ui.Slider) {
 	}
 }
 
-fn alpha_on_char(textbox &ui.TextBox, keycode u32) {
+fn alpha_on_char(textbox &ui.TextBox, _ u32) {
 	mut ac := alpha_component(textbox)
 	if ui.is_rgb_valid(textbox.text.int()) {
 		ac.alpha = textbox.text.int()

--- a/component/colorbox.v
+++ b/component/colorbox.v
@@ -357,7 +357,7 @@ pub fn (mut cb ColorBoxComponent) update_buffer() {
 	ui.update_text_texture(cb.simg, 256, 256, cb.buf)
 }
 
-fn tb_char(tb &ui.TextBox, cp u32) {
+fn tb_char(tb &ui.TextBox, _ u32) {
 	mut cb := colorbox_component(tb)
 	r, g, b := cb.txt_r.int(), cb.txt_g.int(), cb.txt_b.int()
 	cb.update_from_rgb(r, g, b)

--- a/component/colorsliders.v
+++ b/component/colorsliders.v
@@ -231,7 +231,7 @@ fn on_b_value_changed(slider &ui.Slider) {
 	}
 }
 
-fn on_r_char(textbox &ui.TextBox, keycode u32) {
+fn on_r_char(textbox &ui.TextBox, _ u32) {
 	mut cs := colorsliders_component(textbox)
 	if ui.is_rgb_valid(cs.r_textbox.text.int()) {
 		cs.r_slider.val = cs.r_textbox_text.f32()
@@ -244,7 +244,7 @@ fn on_r_char(textbox &ui.TextBox, keycode u32) {
 	}
 }
 
-fn on_g_char(textbox &ui.TextBox, keycode u32) {
+fn on_g_char(textbox &ui.TextBox, _ u32) {
 	mut cs := colorsliders_component(textbox)
 	if ui.is_rgb_valid(cs.g_textbox.text.int()) {
 		cs.g_slider.val = cs.g_textbox_text.f32()
@@ -257,7 +257,7 @@ fn on_g_char(textbox &ui.TextBox, keycode u32) {
 	}
 }
 
-fn on_b_char(textbox &ui.TextBox, keycode u32) {
+fn on_b_char(textbox &ui.TextBox, _ u32) {
 	mut cs := colorsliders_component(textbox)
 	if ui.is_rgb_valid(cs.b_textbox.text.int()) {
 		cs.b_slider.val = cs.b_textbox_text.f32()

--- a/component/demo.v
+++ b/component/demo.v
@@ -10,7 +10,7 @@ pub mut:
 	layout   &ui.Stack = unsafe { nil } // required
 	tb_text  string    = 'textbox text'
 	tbm_text string    = 'textbox multilines text\nsecond line\n' + ('blah blah'.repeat(10) +
-	'blah\n').repeat(20)
+		'blah\n').repeat(20)
 }
 
 @[params]

--- a/component/fontchooser.v
+++ b/component/fontchooser.v
@@ -82,7 +82,7 @@ pub fn fontchooser_connect(w &ui.Window, dtw ui.DrawTextWidget) {
 
 fn fontchooser_lb_change(lb &ui.ListBox) {
 	mut w := lb.ui.window
-	fc := fontchooser_component(lb)
+	mut fc := fontchooser_component(lb)
 	// println('fc_lb_change: $lb.id')
 	mut dtw := ui.DrawTextWidget(fc.dtw)
 	fp, id := lb.selected() or { 'classic', '' }

--- a/component/gg_app.v
+++ b/component/gg_app.v
@@ -57,7 +57,7 @@ fn gg_init(layout &ui.CanvasLayout) {
 	app.on_init()
 }
 
-fn gg_draw(mut d ui.DrawDevice, c &ui.CanvasLayout) {
+fn gg_draw(mut _d ui.DrawDevice, c &ui.CanvasLayout) {
 	mut ggc := gg_component(c)
 	mut app := ggc.app
 	app.on_draw()

--- a/component/grid.v
+++ b/component/grid.v
@@ -296,13 +296,13 @@ fn grid_mouse_down(c &ui.CanvasLayout, e ui.MouseEvent) {
 	}
 }
 
-fn grid_mouse_up(c &ui.CanvasLayout, e ui.MouseEvent) {
+fn grid_mouse_up(c &ui.CanvasLayout, _ ui.MouseEvent) {
 	mut g := grid_component(c)
 	g.edge_w_orig = -1
 	g.edge_x_orig = 0
 }
 
-fn grid_scroll(c &ui.CanvasLayout, e ui.ScrollEvent) {
+fn grid_scroll(_ &ui.CanvasLayout, _ ui.ScrollEvent) {
 }
 
 fn grid_mouse_move(mut c ui.CanvasLayout, e ui.MouseMoveEvent) {

--- a/component/hideable.v
+++ b/component/hideable.v
@@ -73,7 +73,7 @@ fn hideable_init(layout &ui.Stack) {
 
 // TODO: documentation
 pub fn hideable_add_shortcut(w &ui.Window, shortcut string, shortcut_fn ui.ShortcutFn) {
-	mut sc := ui.Shortcutable(w)
+	mut sc := unsafe { ui.Shortcutable(w) }
 	sc.add_shortcut(shortcut, shortcut_fn)
 }
 

--- a/component/rasterview.v
+++ b/component/rasterview.v
@@ -217,11 +217,11 @@ fn rv_click(c &ui.CanvasLayout, e ui.MouseEvent) {
 	}
 }
 
-fn rv_mouse_down(mut c ui.CanvasLayout, e ui.MouseEvent) {
+fn rv_mouse_down(mut c ui.CanvasLayout, _ ui.MouseEvent) {
 	c.focus()
 }
 
-fn rv_mouse_up(c &ui.CanvasLayout, e ui.MouseEvent) {
+fn rv_mouse_up(_ &ui.CanvasLayout, _ ui.MouseEvent) {
 }
 
 fn rv_scroll(c &ui.CanvasLayout, e ui.ScrollEvent) {
@@ -248,14 +248,14 @@ fn rv_mouse_move(mut c ui.CanvasLayout, e ui.MouseMoveEvent) {
 	}
 }
 
-fn rv_mouse_enter(mut c ui.CanvasLayout, e ui.MouseMoveEvent) {
+fn rv_mouse_enter(mut c ui.CanvasLayout, _ ui.MouseMoveEvent) {
 	// mut rv := rasterview_component(c)
 	// if rv.cur_i != -1 && rv.cur_j != -1 {
 	c.ui.window.mouse.start(ui.mouse_hidden)
 	// }
 }
 
-fn rv_mouse_leave(mut c ui.CanvasLayout, e ui.MouseMoveEvent) {
+fn rv_mouse_leave(mut c ui.CanvasLayout, _ ui.MouseMoveEvent) {
 	// mut rv := rasterview_component(c)
 	// if rv.cur_i != -1 || rv.cur_j != -1 {
 	c.ui.window.mouse.stop_last(ui.mouse_hidden)

--- a/component/splitpanel.v
+++ b/component/splitpanel.v
@@ -91,12 +91,12 @@ pub fn splitpanel_component_from_id(w ui.Window, id string) &SplitPanelComponent
 	return splitpanel_component(w.get_or_panic[ui.Stack](ui.component_id(id, 'layout')))
 }
 
-fn splitpanel_btn_mouse_down(b &ui.Button, e &ui.MouseEvent) {
+fn splitpanel_btn_mouse_down(b &ui.Button, _ &ui.MouseEvent) {
 	mut sp := splitpanel_component(b)
 	sp.active = true
 }
 
-fn splitpanel_btn_mouse_up(b &ui.Button, e &ui.MouseEvent) {
+fn splitpanel_btn_mouse_up(b &ui.Button, _ &ui.MouseEvent) {
 	mut sp := splitpanel_component(b)
 	sp.active = false
 }

--- a/component/tabs.v
+++ b/component/tabs.v
@@ -165,7 +165,7 @@ fn tab_key_down(c &ui.CanvasLayout, e ui.KeyEvent) {
 	}
 }
 
-fn tab_click(c &ui.CanvasLayout, e ui.MouseEvent) {
+fn tab_click(c &ui.CanvasLayout, _ ui.MouseEvent) {
 	mut tabs := tabs_component(c)
 	// println("selected $c.id")
 	tabs.layout.children[1] = tabs.pages[c.id]

--- a/examples/7guis/circledrawer.v
+++ b/examples/7guis/circledrawer.v
@@ -220,7 +220,7 @@ fn (mut app App) click_circles(c &ui.CanvasLayout, e ui.MouseEvent) {
 	check_redo_disabled(app.state, mut btn_redo)
 }
 
-fn (mut app App) mouse_move_circles(c &ui.CanvasLayout, e ui.MouseMoveEvent) {
+fn (mut app App) mouse_move_circles(_ &ui.CanvasLayout, e ui.MouseMoveEvent) {
 	app.hover = app.state.point_inside(f32(e.x), f32(e.y))
 }
 

--- a/examples/7guis/counter.v
+++ b/examples/7guis/counter.v
@@ -43,6 +43,6 @@ fn main() {
 	ui.run(window)
 }
 
-fn (mut app App) btn_click(btn &ui.Button) {
+fn (mut app App) btn_click(_ &ui.Button) {
 	app.counter = (app.counter.int() + 1).str()
 }

--- a/examples/7guis/crud.v
+++ b/examples/7guis/crud.v
@@ -122,11 +122,11 @@ fn (mut app App) win_init(win &ui.Window) {
 	app.update_listbox()
 }
 
-fn (mut app App) on_change_filter(mut tb ui.TextBox) {
+fn (mut app App) on_change_filter(mut _ ui.TextBox) {
 	app.update_listbox()
 }
 
-fn (mut app App) btn_create_click(btn &ui.Button) {
+fn (mut app App) btn_create_click(_ &ui.Button) {
 	p := person(app.tb_name.text, app.tb_surname.text)
 	if p.id !in app.people.map(it.id) {
 		app.people << p
@@ -134,11 +134,11 @@ fn (mut app App) btn_create_click(btn &ui.Button) {
 	app.update_listbox()
 }
 
-fn (mut app App) btn_update_click(btn &ui.Button) {
+fn (mut app App) btn_update_click(_ &ui.Button) {
 	app.update_selected_person()
 }
 
-fn (mut app App) btn_delete_click(btn &ui.Button) {
+fn (mut app App) btn_delete_click(_ &ui.Button) {
 	app.delete_selected_person()
 }
 

--- a/examples/7guis/timer.v
+++ b/examples/7guis/timer.v
@@ -75,11 +75,11 @@ fn main() {
 	ui.run(window)
 }
 
-fn (mut app App) on_value_changed(slider &ui.Slider) {
+fn (mut app App) on_value_changed(_ &ui.Slider) {
 	app.duration = app.slider.val
 }
 
-fn (mut app App) on_reset(button &ui.Button) {
+fn (mut app App) on_reset(_ &ui.Button) {
 	app.elapsed_time = 0.0
 	spawn app.timer()
 }

--- a/examples/canvas_plus_gradient_texture.v
+++ b/examples/canvas_plus_gradient_texture.v
@@ -32,13 +32,13 @@ fn main() {
 	ui.run(app.window)
 }
 
-fn (mut app App) init_texture(w &ui.Window) {
+fn (mut app App) init_texture(_ &ui.Window) {
 	app.texture = ui.create_dynamic_texture(256, 256)
 	app.sampler = ui.create_image_sampler()
 	app.buf = unsafe { malloc(256 * 256 * 4) }
 }
 
-fn (app &App) draw_gradient(mut d ui.DrawDevice, c &ui.CanvasLayout) {
+fn (app &App) draw_gradient(mut _ ui.DrawDevice, c &ui.CanvasLayout) {
 	target_hue, _, _ := ui.rgb_to_hsv(gg.rgb(255, 0, 0))
 	mut i := 0
 	for y in 0 .. 256 {

--- a/examples/change_title.v
+++ b/examples/change_title.v
@@ -45,6 +45,6 @@ fn main() {
 	ui.run(app.window)
 }
 
-fn (mut app App) btn_change_title(btn &ui.Button) {
+fn (mut app App) btn_change_title(_ &ui.Button) {
 	app.window.set_title(app.title_box_text)
 }

--- a/examples/child_window.v
+++ b/examples/child_window.v
@@ -30,7 +30,7 @@ fn main() {
 	ui.run(app.window)
 }
 
-fn (mut app App) btn_click(btn &ui.Button) {
+fn (mut app App) btn_click(_ &ui.Button) {
 	app.window.child_window(
 		children: [
 			ui.column(

--- a/examples/component/accordion.v
+++ b/examples/component/accordion.v
@@ -210,10 +210,10 @@ fn dd_change(dd &ui.Dropdown) {
 	println(dd.selected().text)
 }
 
-fn (mut app App) on_hor_value_changed(slider &ui.Slider) {
+fn (mut app App) on_hor_value_changed(_ &ui.Slider) {
 	app.hor_slider.val = app.hor_slider.val
 }
 
-fn (mut app App) on_vert_value_changed(slider &ui.Slider) {
+fn (mut app App) on_vert_value_changed(_ &ui.Slider) {
 	app.vert_slider.val = app.vert_slider.val
 }

--- a/examples/component/grid.v
+++ b/examples/component/grid.v
@@ -45,7 +45,7 @@ fn main() {
 	ui.run(window)
 }
 
-fn win_init(w &ui.Window) {
+fn win_init(_ &ui.Window) {
 	// mut g := uic.grid_component_from_id(w, "grid")
 	// g.init_ranked_grid_data([2, 0], [1, -1])
 

--- a/examples/component/grid2.v
+++ b/examples/component/grid2.v
@@ -58,7 +58,7 @@ fn main() {
 	ui.run(window)
 }
 
-fn win_init(w &ui.Window) {
+fn win_init(_ &ui.Window) {
 	// mut g := uic.grid_component_from_id(w, "grid")
 	// g.init_ranked_grid_data([2, 0], [1, 2])
 

--- a/examples/component/grid_boxlayout.v
+++ b/examples/component/grid_boxlayout.v
@@ -45,7 +45,7 @@ fn main() {
 	ui.run(window)
 }
 
-fn win_init(w &ui.Window) {
+fn win_init(_ &ui.Window) {
 	// mut g := uic.grid_component_from_id(w, "grid")
 	// g.init_ranked_grid_data([2, 0], [1, -1])
 

--- a/examples/demo_logview.v
+++ b/examples/demo_logview.v
@@ -45,7 +45,7 @@ fn (mut app App) wait_complete(mut tb ui.TextBox) {
 	}
 }
 
-fn (mut app App) btn_connect(btn &ui.Button) {
+fn (mut app App) btn_connect(_ &ui.Button) {
 	mut tb := app.window.get_or_panic[ui.TextBox]('tb')
 	spawn app.wait_complete(mut tb)
 }

--- a/examples/demo_text_style.v
+++ b/examples/demo_text_style.v
@@ -94,7 +94,7 @@ fn window_init(mut w ui.Window) {
 }
 
 fn (app &App) on_draw(mut d ui.DrawDevice, c &ui.CanvasLayout) {
-	mut dtw := ui.DrawTextWidget(c)
+	mut dtw := unsafe { ui.DrawTextWidget(c) }
 	dtw.load_style()
 	c.draw_device_text(d, 10, 10, app.text)
 	w, h := dtw.text_size(app.text)
@@ -105,7 +105,7 @@ fn (app &App) on_draw(mut d ui.DrawDevice, c &ui.CanvasLayout) {
 fn (mut app App) lb_change(lb &ui.ListBox) {
 	mut w := lb.ui.window
 	c := w.get_or_panic[ui.CanvasLayout]('c')
-	mut dtw := ui.DrawTextWidget(c)
+	mut dtw := unsafe { ui.DrawTextWidget(c) }
 	fp, id := lb.selected() or { 'classic', '' }
 	// println("$id, $fp")
 	$if windows {

--- a/examples/demo_textbox.v
+++ b/examples/demo_textbox.v
@@ -85,6 +85,6 @@ fn on_switch_click(switcher &ui.Switch) {
 	tb.tv.switch_wordwrap()
 }
 
-fn on_scroll_change(sw ui.ScrollableWidget) {
+fn on_scroll_change(_ ui.ScrollableWidget) {
 	// println('sw cb example: $sw.id has scrollview? $sw.has_scrollview with x: $sw.x and y: $sw.y')
 }

--- a/examples/layout/box_layout_inside_row.v
+++ b/examples/layout/box_layout_inside_row.v
@@ -12,7 +12,7 @@ mut:
 	window &ui.Window = unsafe { nil }
 }
 
-fn make_tb(mut app App, mut text []string, has_row bool) ui.Widget {
+fn make_tb(mut app App, mut _ []string, has_row bool) ui.Widget {
 	app.texts['toto'] = 'blah3 blah blah\n'.repeat(10)
 	tb := ui.textbox(
 		mode:     .multiline

--- a/examples/layout/canvas_layout.v
+++ b/examples/layout/canvas_layout.v
@@ -187,6 +187,6 @@ fn mouse_move(c &ui.CanvasLayout, e ui.MouseMoveEvent) {
 	l.set_text('(${e.x},${e.y})')
 }
 
-fn win_init(mut w ui.Window) {
+fn win_init(mut _ ui.Window) {
 	// w.mouse.start(ui.mouse_hidden)
 }

--- a/examples/layout/canvas_layout_inside_boxlayout.v
+++ b/examples/layout/canvas_layout_inside_boxlayout.v
@@ -204,6 +204,6 @@ fn mouse_move(c &ui.CanvasLayout, e ui.MouseMoveEvent) {
 	l.set_text('(${e.x},${e.y})')
 }
 
-fn win_init(mut w ui.Window) {
+fn win_init(mut _ ui.Window) {
 	// w.mouse.start(ui.mouse_hidden)
 }

--- a/examples/layout/canvas_layout_inside_row.v
+++ b/examples/layout/canvas_layout_inside_row.v
@@ -210,6 +210,6 @@ fn mouse_move(c &ui.CanvasLayout, e ui.MouseMoveEvent) {
 	l.set_text('(${e.x},${e.y})')
 }
 
-fn win_init(mut w ui.Window) {
+fn win_init(mut _ ui.Window) {
 	// w.mouse.start(ui.mouse_hidden)
 }

--- a/examples/layout/row_layout.v
+++ b/examples/layout/row_layout.v
@@ -316,7 +316,7 @@ fn set_sizes_labels(win &ui.Window) {
 	row_btn2.title = 'Btn2: (${w}, ${h})'
 }
 
-fn win_resize(win &ui.Window, w int, h int) {
+fn win_resize(win &ui.Window, _ int, _ int) {
 	set_sizes_labels(win)
 }
 

--- a/examples/rgb_color.v
+++ b/examples/rgb_color.v
@@ -142,30 +142,30 @@ fn main() {
 	ui.run(app.window)
 }
 
-fn (app &App) btn_click(b &ui.Button) {
+fn (app &App) btn_click(_ &ui.Button) {
 	txt := 'gg.rgb(${app.r_textbox_text},${app.g_textbox_text},${app.b_textbox_text})'
 	ui.message_box(txt)
 }
 
-fn (mut app App) on_r_value_changed(slider &ui.Slider) {
+fn (mut app App) on_r_value_changed(_ &ui.Slider) {
 	app.r_textbox_text = int(app.r_slider.val).str()
 	app.r_textbox.border_accentuated = false
 	textbox_color_update(mut app)
 }
 
-fn (mut app App) on_g_value_changed(slider &ui.Slider) {
+fn (mut app App) on_g_value_changed(_ &ui.Slider) {
 	app.g_textbox_text = int(app.g_slider.val).str()
 	app.g_textbox.border_accentuated = false
 	textbox_color_update(mut app)
 }
 
-fn (mut app App) on_b_value_changed(slider &ui.Slider) {
+fn (mut app App) on_b_value_changed(_ &ui.Slider) {
 	app.b_textbox_text = int(app.b_slider.val).str()
 	app.b_textbox.border_accentuated = false
 	textbox_color_update(mut app)
 }
 
-fn (mut app App) on_r_char(textbox &ui.TextBox, keycode u32) {
+fn (mut app App) on_r_char(_ &ui.TextBox, _ u32) {
 	if ui.is_rgb_valid(app.r_textbox.text.int()) {
 		app.r_slider.val = app.r_textbox_text.f32()
 		app.r_textbox.border_accentuated = false
@@ -175,7 +175,7 @@ fn (mut app App) on_r_char(textbox &ui.TextBox, keycode u32) {
 	textbox_color_update(mut app)
 }
 
-fn (mut app App) on_g_char(textbox &ui.TextBox, keycode u32) {
+fn (mut app App) on_g_char(_ &ui.TextBox, _ u32) {
 	if ui.is_rgb_valid(app.g_textbox.text.int()) {
 		app.g_slider.val = app.g_textbox_text.f32()
 		app.g_textbox.border_accentuated = false
@@ -185,7 +185,7 @@ fn (mut app App) on_g_char(textbox &ui.TextBox, keycode u32) {
 	textbox_color_update(mut app)
 }
 
-fn (mut app App) on_b_char(textbox &ui.TextBox, keycode u32) {
+fn (mut app App) on_b_char(_ &ui.TextBox, _ u32) {
 	if ui.is_rgb_valid(app.b_textbox.text.int()) {
 		app.b_slider.val = app.b_textbox_text.f32()
 		app.b_textbox.border_accentuated = false

--- a/examples/slider.v
+++ b/examples/slider.v
@@ -47,10 +47,10 @@ fn main() {
 	ui.run(app.window)
 }
 
-fn (mut app App) on_hor_value_changed(slider &ui.Slider) {
+fn (mut app App) on_hor_value_changed(_ &ui.Slider) {
 	app.hor_slider.val = app.hor_slider.val
 }
 
-fn (mut app App) on_vert_value_changed(slider &ui.Slider) {
+fn (mut app App) on_vert_value_changed(_ &ui.Slider) {
 	app.vert_slider.val = app.vert_slider.val
 }

--- a/examples/textbox_input/textbox_demo_default.c.v
+++ b/examples/textbox_input/textbox_demo_default.c.v
@@ -1,6 +1,6 @@
 import ui
 
-fn (mut a App) init(window &ui.Window) {
+fn (mut a App) init(_ &ui.Window) {
 	// Stub
 }
 

--- a/src/button.v
+++ b/src/button.v
@@ -226,7 +226,7 @@ fn native_button_clicked(v_button voidptr) {
 	}
 }
 
-fn btn_key_down(mut b Button, e &KeyEvent, window &Window) {
+fn btn_key_down(mut b Button, e &KeyEvent, _ &Window) {
 	// println('key down $e <$e.key> <$e.codepoint> <$e.mods>')
 	// println('key down key=<$e.key> code=<$e.codepoint> mods=<$e.mods>')
 	$if btn_keydown ? {
@@ -251,7 +251,7 @@ fn btn_key_down(mut b Button, e &KeyEvent, window &Window) {
 	}
 }
 
-fn btn_click(mut b Button, e &MouseEvent, window &Window) {
+fn btn_click(mut b Button, e &MouseEvent, _ &Window) {
 	$if btn_click ? {
 		println('btn_click ${b.id} movable ${b.movable} focused ${b.is_focused} top_widget ${b.ui.window.is_top_widget(b,
 			events.on_mouse_down)}')
@@ -288,7 +288,7 @@ fn btn_click(mut b Button, e &MouseEvent, window &Window) {
 	}
 }
 
-fn btn_mouse_down(mut b Button, e &MouseEvent, window &Window) {
+fn btn_mouse_down(mut b Button, e &MouseEvent, _ &Window) {
 	$if btn_md ? {
 		println('btn_mouse_down ${b.id} movable ${b.movable} top_widget ${b.ui.window.is_top_widget(b,
 			events.on_mouse_down)}')
@@ -313,7 +313,7 @@ fn btn_mouse_down(mut b Button, e &MouseEvent, window &Window) {
 	}
 }
 
-fn btn_mouse_up(mut b Button, e &MouseEvent, window &Window) {
+fn btn_mouse_up(mut b Button, e &MouseEvent, _ &Window) {
 	$if btn_mu ? {
 		println('btn_mu ${b.id}')
 	}
@@ -326,7 +326,7 @@ fn btn_mouse_up(mut b Button, e &MouseEvent, window &Window) {
 	}
 }
 
-fn btn_mouse_move(mut b Button, e &MouseMoveEvent, window &Window) {
+fn btn_mouse_move(mut b Button, e &MouseMoveEvent, _ &Window) {
 	// println('btn_click for window=$window.title')
 	if b.hidden {
 		return

--- a/src/chunkview.v
+++ b/src/chunkview.v
@@ -114,12 +114,12 @@ pub fn imgchunk(p ImageChunkParams) ImageChunk {
 	}
 }
 
-fn (mut c ImageChunk) init(cv &ChunkView) {}
+fn (mut c ImageChunk) init(_ &ChunkView) {}
 
-fn (mut c ImageChunk) draw_device(mut d DrawDevice, cv &ChunkView, offset Offset) {
+fn (mut c ImageChunk) draw_device(mut _ DrawDevice, _ &ChunkView, _ Offset) {
 }
 
-fn (mut c ImageChunk) update_bounding_box(cv &ChunkView, offset Offset) {
+fn (mut c ImageChunk) update_bounding_box(_ &ChunkView, _ Offset) {
 }
 
 type DrawChunkFn = fn (&DrawChunk)
@@ -138,12 +138,12 @@ pub fn drawchunk(drawfn DrawChunkFn, state voidptr) DrawChunk {
 	}
 }
 
-fn (mut c DrawChunk) init(cv &ChunkView) {}
+fn (mut c DrawChunk) init(_ &ChunkView) {}
 
-fn (mut c DrawChunk) draw_device(mut d DrawDevice, cv &ChunkView, offset Offset) {
+fn (mut c DrawChunk) draw_device(mut _ DrawDevice, _ &ChunkView, _ Offset) {
 }
 
-fn (mut c DrawChunk) update_bounding_box(cv &ChunkView, offset Offset) {
+fn (mut c DrawChunk) update_bounding_box(_ &ChunkView, _ Offset) {
 }
 
 // Arrange chunk as a paragraph
@@ -573,7 +573,7 @@ fn (mut c VerticalAlignChunk) init_line_chunks(cv &ChunkView) {
 	// println("line_chunks = $c.line_chunks")
 }
 
-fn (mut c VerticalAlignChunk) update_chunks(cv &ChunkView) {
+fn (mut c VerticalAlignChunk) update_chunks(_ &ChunkView) {
 	c.update_clipping()
 	max_line_width := c.width - 10 // c.container?.inner_size()
 	winf, wsup := -c.align * max_line_width, (f32(1) - c.align) * max_line_width

--- a/src/chunkview.v
+++ b/src/chunkview.v
@@ -80,12 +80,12 @@ fn (mut c TextChunk) init(cv &ChunkView) {
 }
 
 fn (mut c TextChunk) draw_device(mut d DrawDevice, cv &ChunkView, offset Offset) {
-	mut dtw := DrawTextWidget(cv)
+	mut dtw := unsafe { DrawTextWidget(cv) }
 	dtw.draw_device_styled_text(d, cv.x + offset.x + c.x, cv.y + offset.y + c.y, c.text, id: c.style)
 }
 
 fn (mut c TextChunk) update_bounding_box(cv &ChunkView, offset Offset) {
-	mut dtw := DrawTextWidget(cv)
+	mut dtw := unsafe { DrawTextWidget(cv) }
 	cv.load_style(c.style)
 	// c.bb.w, c.bb.h = dtw.text_size(c.text)
 	// println("style: ${c.style} bb: ${c.bb} text_bounds ${dtw.text_bounds(c.x, c.y, c.text)}")
@@ -210,7 +210,7 @@ fn (mut c ParaChunk) update_clipping() {
 }
 
 fn (mut c ParaChunk) update_line_height(cv &ChunkView) {
-	mut dtw := DrawTextWidget(cv)
+	mut dtw := unsafe { DrawTextWidget(cv) }
 	mut lh := 0
 	mut style, mut left := '', ''
 	for content in c.content {
@@ -234,7 +234,7 @@ fn (mut c ParaChunk) update_chunks(cv &ChunkView) {
 	max_line_width := c.width - 10
 	// max_line_width, _ := c.container?.inner_size()
 	// println("max_line_width=${max_line_width}")
-	mut dtw := DrawTextWidget(cv)
+	mut dtw := unsafe { DrawTextWidget(cv) }
 	// convert content to chunks
 	mut chunks := []ChunkContent{}
 	mut style := ''
@@ -490,7 +490,7 @@ fn (mut c VerticalAlignChunk) inner_size() (int, int) {
 }
 
 fn (mut c VerticalAlignChunk) update_line_height(cv &ChunkView) {
-	mut dtw := DrawTextWidget(cv)
+	mut dtw := unsafe { DrawTextWidget(cv) }
 	mut lh := 0
 	mut style, mut left := '', ''
 	for content in c.content {
@@ -511,7 +511,7 @@ fn (mut c VerticalAlignChunk) update_line_height(cv &ChunkView) {
 
 // only once in init
 fn (mut c VerticalAlignChunk) init_line_chunks(cv &ChunkView) {
-	mut dtw := DrawTextWidget(cv)
+	mut dtw := unsafe { DrawTextWidget(cv) }
 	// split c.content into the lines 'br' being the separator
 	mut contents := [][]string{}
 	mut lines := []string{}
@@ -818,7 +818,7 @@ fn (mut cv ChunkView) init(parent Layout) {
 }
 
 fn (cv &ChunkView) load_style(style string) {
-	mut dtw := DrawTextWidget(cv)
+	mut dtw := unsafe { DrawTextWidget(cv) }
 	dtw.set_current_style(id: style) // to update style for text_width_additive
 	dtw.load_style()
 }

--- a/src/dropdown.v
+++ b/src/dropdown.v
@@ -240,7 +240,7 @@ fn (mut dd Dropdown) open_drawer() {
 	dd.focus()
 }
 
-fn dd_key_down(mut dd Dropdown, e &KeyEvent, zzz voidptr) {
+fn dd_key_down(mut dd Dropdown, e &KeyEvent, _ voidptr) {
 	if dd.hidden || !dd.is_focused {
 		return
 	}
@@ -277,7 +277,7 @@ fn dd_key_down(mut dd Dropdown, e &KeyEvent, zzz voidptr) {
 	}
 }
 
-fn dd_click(mut dd Dropdown, e &MouseEvent, zzz voidptr) {
+fn dd_click(mut dd Dropdown, e &MouseEvent, _ voidptr) {
 	$if dd_click ? {
 		println('${dd.id} click ${dd.hidden} ${dd.is_focused} ${dd.z_index}')
 	}
@@ -304,7 +304,7 @@ fn dd_click(mut dd Dropdown, e &MouseEvent, zzz voidptr) {
 	offset_end(mut dd)
 }
 
-fn dd_mouse_down(mut dd Dropdown, e &MouseEvent, zzz voidptr) {
+fn dd_mouse_down(mut dd Dropdown, e &MouseEvent, _ voidptr) {
 	if dd.hidden {
 		return
 	}
@@ -316,7 +316,7 @@ fn dd_mouse_down(mut dd Dropdown, e &MouseEvent, zzz voidptr) {
 	}
 }
 
-fn dd_mouse_move(mut dd Dropdown, e &MouseMoveEvent, zzz voidptr) {
+fn dd_mouse_move(mut dd Dropdown, e &MouseMoveEvent, _ voidptr) {
 	if dd.hidden {
 		return
 	}

--- a/src/layout_box.v
+++ b/src/layout_box.v
@@ -455,7 +455,7 @@ pub fn (b &BoxLayout) set_child_size(i int, mut child Widget) {
 	child.propose_size(w, h)
 }
 
-fn (b BoxLayout) ids_repl(re regex.RE, in_txt string, start int, end int) string {
+fn (b BoxLayout) ids_repl(re regex.RE, in_txt string, _ int, _ int) string {
 	id := re.get_group_by_id(in_txt, 0)
 	field := re.get_group_by_id(in_txt, 1)
 	ind := b.child_id.index(id)
@@ -481,7 +481,7 @@ fn (b BoxLayout) ids_repl(re regex.RE, in_txt string, start int, end int) string
 	return in_txt
 }
 
-fn (mut b BoxLayout) preprocess_child_box_expression(i int, id string) {
+fn (mut b BoxLayout) preprocess_child_box_expression(_ int, id string) {
 	// TODO: extract first the @id, replace by unsafe value in the expression
 	// the new bounding string is then evaluated to generate b.child_box[i]
 	// temporary modify b.child_mode[i] to the evaluated mode

--- a/src/layout_canvas.v
+++ b/src/layout_canvas.v
@@ -314,7 +314,7 @@ fn (mut c CanvasLayout) init_size() {
 	scrollview_update(c)
 }
 
-fn canvas_layout_delegate(mut c CanvasLayout, e &gg.Event, window &Window) {
+fn canvas_layout_delegate(mut c CanvasLayout, e &gg.Event, _ &Window) {
 	if !c.point_inside(e.mouse_x / c.ui.window.dpi_scale, e.mouse_y / c.ui.window.dpi_scale) {
 		return
 	}
@@ -323,7 +323,7 @@ fn canvas_layout_delegate(mut c CanvasLayout, e &gg.Event, window &Window) {
 	}
 }
 
-fn canvas_layout_click(mut c CanvasLayout, e &MouseEvent, window &Window) {
+fn canvas_layout_click(mut c CanvasLayout, e &MouseEvent, _ &Window) {
 	$if cl_click ? {
 		if c.point_inside(e.x, e.y) {
 			println('clc ${c.id} ${c.z_index} (${e.x}, ${e.y}) ${c.point_inside(e.x, e.y)} ${c.ui.window.is_top_widget(c,
@@ -352,7 +352,7 @@ fn canvas_layout_click(mut c CanvasLayout, e &MouseEvent, window &Window) {
 	}
 }
 
-fn canvas_layout_mouse_down(mut c CanvasLayout, e &MouseEvent, window &Window) {
+fn canvas_layout_mouse_down(mut c CanvasLayout, e &MouseEvent, _ &Window) {
 	if c.hidden {
 		return
 	}
@@ -371,7 +371,7 @@ fn canvas_layout_mouse_down(mut c CanvasLayout, e &MouseEvent, window &Window) {
 	}
 }
 
-fn canvas_layout_mouse_up(mut c CanvasLayout, e &MouseEvent, window &Window) {
+fn canvas_layout_mouse_up(mut c CanvasLayout, e &MouseEvent, _ &Window) {
 	if c.hidden {
 		return
 	}
@@ -387,7 +387,7 @@ fn canvas_layout_mouse_up(mut c CanvasLayout, e &MouseEvent, window &Window) {
 	}
 }
 
-fn canvas_layout_mouse_move(mut c CanvasLayout, e &MouseMoveEvent, window &Window) {
+fn canvas_layout_mouse_move(mut c CanvasLayout, e &MouseMoveEvent, _ &Window) {
 	if c.hidden {
 		return
 	}
@@ -427,7 +427,7 @@ pub fn (mut c CanvasLayout) mouse_leave(e &MouseMoveEvent) {
 	}
 }
 
-fn canvas_layout_scroll(mut c CanvasLayout, e &ScrollEvent, window &Window) {
+fn canvas_layout_scroll(mut c CanvasLayout, e &ScrollEvent, _ &Window) {
 	if c.scroll_fn != unsafe { CanvasLayoutScrollFn(0) } {
 		e2 := ScrollEvent{
 			mouse_x: e.mouse_x - c.x - c.offset_x
@@ -439,7 +439,7 @@ fn canvas_layout_scroll(mut c CanvasLayout, e &ScrollEvent, window &Window) {
 	}
 }
 
-fn canvas_layout_key_down(mut c CanvasLayout, e &KeyEvent, window &Window) {
+fn canvas_layout_key_down(mut c CanvasLayout, e &KeyEvent, _ &Window) {
 	// println('key down $c.id $c.hidden $e')
 	if c.hidden {
 		return
@@ -452,7 +452,7 @@ fn canvas_layout_key_down(mut c CanvasLayout, e &KeyEvent, window &Window) {
 	}
 }
 
-fn canvas_layout_char(mut c CanvasLayout, e &KeyEvent, window &Window) {
+fn canvas_layout_char(mut c CanvasLayout, e &KeyEvent, _ &Window) {
 	// println('key down $e')
 	if c.hidden {
 		return

--- a/src/layout_canvas.v
+++ b/src/layout_canvas.v
@@ -873,21 +873,21 @@ pub fn (c &CanvasLayout) draw_text(x int, y int, text string) {
 
 // TODO: documentation
 pub fn (c &CanvasLayout) draw_device_text(d DrawDevice, x int, y int, text string) {
-	mut dtw := DrawTextWidget(c)
+	dtw := unsafe { DrawTextWidget(c) }
 	// println("dt $x + $c.x + $c.offset_x, $y + $c.y + $c.offset_y, $text")
 	dtw.draw_device_text(d, x + c.x + c.offset_x, y + c.y + c.offset_y, text)
 }
 
 // TODO: documentation
 pub fn (c &CanvasLayout) draw_styled_text(x int, y int, text string, ts TextStyleParams) {
-	mut dtw := DrawTextWidget(c)
+	mut dtw := unsafe { DrawTextWidget(c) }
 	dtw.draw_device_styled_text(c.ui.dd, x + c.x + c.offset_x, y + c.y + c.offset_y, text,
 		ts)
 }
 
 // TODO: documentation
 pub fn (c &CanvasLayout) draw_device_styled_text(d DrawDevice, x int, y int, text string, ts TextStyleParams) {
-	mut dtw := DrawTextWidget(c)
+	mut dtw := unsafe { DrawTextWidget(c) }
 	dtw.draw_device_styled_text(d, x + c.x + c.offset_x, y + c.y + c.offset_y, text, ts)
 }
 

--- a/src/layout_group.v
+++ b/src/layout_group.v
@@ -198,7 +198,7 @@ fn (g &Group) get_ui() &UI {
 	return g.ui
 }
 
-fn (g &Group) resize(width int, height int) {
+fn (g &Group) resize(_ int, _ int) {
 }
 
 fn (g &Group) get_subscriber() &eventbus.Subscriber[string] {
@@ -206,7 +206,7 @@ fn (g &Group) get_subscriber() &eventbus.Subscriber[string] {
 	return parent.get_subscriber()
 }
 
-fn (mut g Group) set_adjusted_size(i int, u &UI) {
+fn (mut g Group) set_adjusted_size(i int, _ &UI) {
 	mut h, mut w := 0, 0
 	for mut child in g.children {
 		mut child_width, mut child_height := child.size()

--- a/src/listbox.v
+++ b/src/listbox.v
@@ -605,7 +605,7 @@ fn (lb &ListBox) point_inside(x f64, y f64) bool {
 	}
 }
 
-fn on_change(mut lb ListBox, e &MouseEvent, window &Window) {
+fn on_change(mut lb ListBox, e &MouseEvent, _ &Window) {
 	// println("onclick $e.action ${int(e.action)}")
 	if lb.hidden {
 		return
@@ -653,7 +653,7 @@ pub fn (lb &ListBox) call_on_change() {
 	}
 }
 
-fn lb_mouse_down(mut lb ListBox, e &MouseEvent, window &Window) {
+fn lb_mouse_down(mut lb ListBox, e &MouseEvent, _ &Window) {
 	$if lb_md ? {
 		println('lb_mouse_down ${lb.id} top_widget ${lb.ui.window.is_top_widget(lb, events.on_mouse_down)}')
 	}
@@ -679,7 +679,7 @@ fn lb_mouse_down(mut lb ListBox, e &MouseEvent, window &Window) {
 	}
 }
 
-fn lb_mouse_up(mut lb ListBox, e &MouseEvent, window &Window) {
+fn lb_mouse_up(mut lb ListBox, e &MouseEvent, _ &Window) {
 	// println('lb_mu')
 	if lb.hidden {
 		return
@@ -696,7 +696,7 @@ fn lb_mouse_up(mut lb ListBox, e &MouseEvent, window &Window) {
 	// b.state = .normal
 }
 
-fn lb_mouse_move(mut lb ListBox, e &MouseMoveEvent, window &Window) {
+fn lb_mouse_move(mut lb ListBox, e &MouseMoveEvent, _ &Window) {
 	// println('lb move $lb.id')
 	if lb.hidden {
 		return
@@ -741,7 +741,7 @@ fn lb_mouse_move(mut lb ListBox, e &MouseMoveEvent, window &Window) {
 	}
 }
 
-fn on_files_dropped(mut lb ListBox, e &MouseEvent, window &Window) {
+fn on_files_dropped(mut lb ListBox, e &MouseEvent, _ &Window) {
 	// println("on_files_dropped")
 	if lb.hidden {
 		return
@@ -763,7 +763,7 @@ fn on_files_dropped(mut lb ListBox, e &MouseEvent, window &Window) {
 }
 
 // Up and Down keys work on the list when it's is_focused
-fn lb_key_up(mut lb ListBox, e &KeyEvent, window &Window) {
+fn lb_key_up(mut lb ListBox, e &KeyEvent, _ &Window) {
 	if lb.hidden {
 		return
 	}

--- a/src/listbox.v
+++ b/src/listbox.v
@@ -679,7 +679,7 @@ fn lb_mouse_down(mut lb ListBox, e &MouseEvent, _ &Window) {
 	}
 }
 
-fn lb_mouse_up(mut lb ListBox, e &MouseEvent, _ &Window) {
+fn lb_mouse_up(mut lb ListBox, _ &MouseEvent, _ &Window) {
 	// println('lb_mu')
 	if lb.hidden {
 		return
@@ -1060,7 +1060,7 @@ fn (li &ListItem) draw_device(d DrawDevice) {
 	d.draw_rect_filled(li.x + li.offset_x + lb.x + listbox_text_offset_x, li.y + li.offset_y +
 		lb.y + lb.text_offset_y, width - 2 * listbox_text_offset_x, lb.item_height, col)
 
-	mut dtw := DrawTextWidget(lb)
+	mut dtw := unsafe { DrawTextWidget(lb) }
 	dtw.draw_device_styled_text(d, li.x + li.offset_x + lb.x + listbox_text_offset_x,
 		li.y + li.offset_y + lb.y + lb.text_offset_y, if lb.has_scrollview {
 		li.text

--- a/src/menu.v
+++ b/src/menu.v
@@ -190,7 +190,7 @@ fn (mut m Menu) propagate_connection() {
 	}
 }
 
-fn menu_click(mut m Menu, e &MouseEvent, window &Window) {
+fn menu_click(mut m Menu, e &MouseEvent, _ &Window) {
 	if m.hidden {
 		return
 	}
@@ -227,7 +227,7 @@ fn menu_click(mut m Menu, e &MouseEvent, window &Window) {
 	}
 }
 
-fn menu_mouse_move(mut m Menu, e &MouseMoveEvent, window &Window) {
+fn menu_mouse_move(mut m Menu, e &MouseMoveEvent, _ &Window) {
 	if m.hidden {
 		return
 	}

--- a/src/picture.v
+++ b/src/picture.v
@@ -150,7 +150,7 @@ pub fn (p &Picture) free() {
 	}
 }
 
-fn pic_click(mut pic Picture, e &MouseEvent, window &Window) {
+fn pic_click(mut pic Picture, e &MouseEvent, _ &Window) {
 	if pic.hidden {
 		return
 	}
@@ -163,7 +163,7 @@ fn pic_click(mut pic Picture, e &MouseEvent, window &Window) {
 	}
 }
 
-fn pic_mouse_down(mut pic Picture, e &MouseEvent, window &Window) {
+fn pic_mouse_down(mut pic Picture, e &MouseEvent, _ &Window) {
 	if pic.hidden {
 		return
 	}

--- a/src/radio.v
+++ b/src/radio.v
@@ -156,7 +156,7 @@ pub fn (r &Radio) free() {
 // 	dtw.update_text_size(r.text_size)
 // }
 
-fn radio_key_down(mut r Radio, e &KeyEvent, window &Window) {
+fn radio_key_down(mut r Radio, e &KeyEvent, _ &Window) {
 	// println('key down $e <$e.key> <$e.codepoint> <$e.mods>')
 	// println('key down key=<$e.key> code=<$e.codepoint> mods=<$e.mods>')
 	$if radio_keydown ? {
@@ -180,7 +180,7 @@ fn radio_key_down(mut r Radio, e &KeyEvent, window &Window) {
 	}
 }
 
-fn radio_click(mut r Radio, e &MouseEvent, window &Window) {
+fn radio_click(mut r Radio, e &MouseEvent, _ &Window) {
 	if r.hidden {
 		return
 	}

--- a/src/slider.v
+++ b/src/slider.v
@@ -276,7 +276,7 @@ fn (s &Slider) draw_device_thumb(d DrawDevice) {
 	}
 }
 
-fn slider_key_down(mut s Slider, e &KeyEvent, zzz voidptr) {
+fn slider_key_down(mut s Slider, e &KeyEvent, _ voidptr) {
 	if s.hidden {
 		return
 	}
@@ -367,7 +367,7 @@ fn (s &Slider) point_inside_thumb(x f64, y f64) bool {
 	}
 }
 
-fn slider_click(mut s Slider, e &MouseEvent, zzz voidptr) {
+fn slider_click(mut s Slider, e &MouseEvent, _ voidptr) {
 	if s.hidden {
 		return
 	}
@@ -381,7 +381,7 @@ fn slider_click(mut s Slider, e &MouseEvent, zzz voidptr) {
 	s.is_focused = true
 }
 
-fn slider_mouse_down(mut s Slider, e &MouseEvent, zzz voidptr) {
+fn slider_mouse_down(mut s Slider, e &MouseEvent, _ voidptr) {
 	if s.hidden {
 		return
 	}
@@ -392,12 +392,12 @@ fn slider_mouse_down(mut s Slider, e &MouseEvent, zzz voidptr) {
 	}
 }
 
-fn slider_mouse_up(mut s Slider, e &MouseEvent, zzz voidptr) {
+fn slider_mouse_up(mut s Slider, e &MouseEvent, _ voidptr) {
 	// println('slider touchup  NO MORE DRAGGING')
 	s.dragging = false
 }
 
-fn slider_mouse_move(mut s Slider, e &MouseMoveEvent, zzz voidptr) {
+fn slider_mouse_move(mut s Slider, e &MouseMoveEvent, _ voidptr) {
 	// println("slider: $s.dragging ${e.mouse_button} ${int(e.mouse_button)}")
 	if s.ui.btn_down[0] { // int(e.mouse_button) == 0 {
 		// left: 0, right: 1, middle: 2
@@ -413,7 +413,7 @@ fn slider_mouse_move(mut s Slider, e &MouseMoveEvent, zzz voidptr) {
 	}
 }
 
-fn slider_touch_move(mut s Slider, e &MouseMoveEvent, zzz voidptr) {
+fn slider_touch_move(mut s Slider, e &MouseMoveEvent, _ voidptr) {
 	if s.hidden {
 		return
 	}

--- a/src/slider.v
+++ b/src/slider.v
@@ -392,7 +392,7 @@ fn slider_mouse_down(mut s Slider, e &MouseEvent, _ voidptr) {
 	}
 }
 
-fn slider_mouse_up(mut s Slider, e &MouseEvent, _ voidptr) {
+fn slider_mouse_up(mut s Slider, _ &MouseEvent, _ voidptr) {
 	// println('slider touchup  NO MORE DRAGGING')
 	s.dragging = false
 }

--- a/src/stack.v
+++ b/src/stack.v
@@ -1303,7 +1303,7 @@ pub fn (mut s Stack) set_visible(state bool) {
 	}
 }
 
-fn (mut s Stack) resize(width int, height int) {
+fn (mut s Stack) resize(_ int, _ int) {
 	s.init_size()
 	s.update_pos()
 	// scrollview_widget_set_orig_xy(s, false)

--- a/src/subwindow.v
+++ b/src/subwindow.v
@@ -138,7 +138,7 @@ pub fn (s &SubWindow) free() {
 	}
 }
 
-fn sw_mouse_down(mut s SubWindow, e &MouseEvent, window &Window) {
+fn sw_mouse_down(mut s SubWindow, e &MouseEvent, _ &Window) {
 	// println("sw_md: $s.id -> ${window.point_inside_receivers(events.on_mouse_down)}")
 	if s.hidden {
 		return
@@ -160,7 +160,7 @@ fn sw_mouse_down(mut s SubWindow, e &MouseEvent, window &Window) {
 	}
 }
 
-fn sw_mouse_up(mut s SubWindow, e &MouseEvent, window &Window) {
+fn sw_mouse_up(mut s SubWindow, e &MouseEvent, _ &Window) {
 	if s.hidden {
 		return
 	}
@@ -169,7 +169,7 @@ fn sw_mouse_up(mut s SubWindow, e &MouseEvent, window &Window) {
 	s.delegate_size()
 }
 
-fn sw_mouse_move(mut s SubWindow, e &MouseMoveEvent, window &Window) {
+fn sw_mouse_move(mut s SubWindow, e &MouseMoveEvent, _ &Window) {
 	// println('btn_click for window=$window.title')
 	if s.hidden {
 		return
@@ -246,7 +246,7 @@ pub fn (mut s SubWindow) update_layout() {
 	s.layout.update_layout()
 }
 
-fn (mut s SubWindow) set_adjusted_size(u &UI) {
+fn (mut s SubWindow) set_adjusted_size(_ &UI) {
 }
 
 fn (mut s SubWindow) point_inside_bar(x f64, y f64) bool {

--- a/src/subwindow.v
+++ b/src/subwindow.v
@@ -160,7 +160,7 @@ fn sw_mouse_down(mut s SubWindow, e &MouseEvent, _ &Window) {
 	}
 }
 
-fn sw_mouse_up(mut s SubWindow, e &MouseEvent, _ &Window) {
+fn sw_mouse_up(mut s SubWindow, _ &MouseEvent, _ &Window) {
 	if s.hidden {
 		return
 	}

--- a/src/switch.v
+++ b/src/switch.v
@@ -154,7 +154,7 @@ fn (s &Switch) point_inside(x f64, y f64) bool {
 	return point_inside(s, x, y)
 }
 
-fn sw_key_down(mut s Switch, e &KeyEvent, window &Window) {
+fn sw_key_down(mut s Switch, e &KeyEvent, _ &Window) {
 	// println('key down $e <$e.key> <$e.codepoint> <$e.mods>')
 	// println('key down key=<$e.key> code=<$e.codepoint> mods=<$e.mods>')
 	$if sw_keydown ? {
@@ -180,7 +180,7 @@ fn sw_key_down(mut s Switch, e &KeyEvent, window &Window) {
 	}
 }
 
-fn sw_click(mut s Switch, e &MouseEvent, w &Window) {
+fn sw_click(mut s Switch, e &MouseEvent, _ &Window) {
 	if s.hidden {
 		return
 	}

--- a/src/textbox.v
+++ b/src/textbox.v
@@ -307,7 +307,7 @@ fn (tb &TextBox) adj_size() (int, int) {
 	if tb.is_multiline {
 		return tb.tv.size()
 	} else {
-		mut dtw := DrawTextWidget(tb)
+		mut dtw := unsafe { DrawTextWidget(tb) }
 		dtw.load_style()
 		mut w, mut h := dtw.text_size(tb.text)
 		return w + 2 * textbox_padding_x, h + 2 * textbox_padding_y
@@ -1134,7 +1134,7 @@ fn (tb &TextBox) set_children_pos() {}
 // Utility functions
 
 pub fn (tb &TextBox) text_xminmax_from_pos(text string, x1 int, x2 int) (int, int) {
-	mut dtw := DrawTextWidget(tb)
+	mut dtw := unsafe { DrawTextWidget(tb) }
 	dtw.load_style()
 	ustr := text.runes()
 	mut x_min, mut x_max := if x1 < x2 { x1, x2 } else { x2, x1 }
@@ -1157,7 +1157,7 @@ pub fn (tb &TextBox) text_pos_from_x(text string, x int) int {
 	if x <= 0 {
 		return 0
 	}
-	mut dtw := DrawTextWidget(tb)
+	mut dtw := unsafe { DrawTextWidget(tb) }
 	dtw.load_style()
 	mut prev_width := 0
 	ustr := text.runes()

--- a/src/textbox.v
+++ b/src/textbox.v
@@ -551,7 +551,7 @@ pub fn (mut tb TextBox) delete_selection() {
 	tb.cancel_selection()
 }
 
-fn tb_key_down(mut tb TextBox, e &KeyEvent, window &Window) {
+fn tb_key_down(mut tb TextBox, e &KeyEvent, _ &Window) {
 	$if tb_keydown ? {
 		println('tb_keydown id:${tb.id}  -> hidden:${tb.hidden} focused:${tb.is_focused}')
 		println(e)
@@ -728,7 +728,7 @@ fn tb_key_down(mut tb TextBox, e &KeyEvent, window &Window) {
 	}
 }
 
-fn tb_char(mut tb TextBox, e &KeyEvent, window &Window) {
+fn tb_char(mut tb TextBox, e &KeyEvent, _ &Window) {
 	// println('key down $e <$e.key> <$e.codepoint> <$e.mods>')
 	// println('key down key=<$e.key> code=<$e.codepoint> mods=<$e.mods>')
 	$if tb_char ? {
@@ -873,7 +873,7 @@ fn tb_char(mut tb TextBox, e &KeyEvent, window &Window) {
 	}
 }
 
-fn (mut tb TextBox) set_sel(sel_start_i int, sel_end_i int, key Key) {
+fn (mut tb TextBox) set_sel(sel_start_i int, sel_end_i int, _ Key) {
 	if tb.sel_direction == .right_to_left {
 		tb.sel_start = sel_start_i
 		tb.sel_end = sel_end_i
@@ -951,7 +951,7 @@ fn (tb &TextBox) point_inside(x f64, y f64) bool {
 	}
 }
 
-fn tb_mouse_down(mut tb TextBox, e &MouseEvent, zzz voidptr) {
+fn tb_mouse_down(mut tb TextBox, e &MouseEvent, _ voidptr) {
 	// println("mouse first $tb.id")
 	if tb.hidden {
 		return
@@ -1018,7 +1018,7 @@ fn tb_mouse_down(mut tb TextBox, e &MouseEvent, zzz voidptr) {
 	}
 }
 
-fn tb_mouse_move(mut tb TextBox, e &MouseMoveEvent, zzz voidptr) {
+fn tb_mouse_move(mut tb TextBox, e &MouseMoveEvent, _ voidptr) {
 	if tb.hidden {
 		return
 	}
@@ -1051,7 +1051,7 @@ pub fn (mut tb TextBox) mouse_leave(e &MouseMoveEvent) {
 	}
 }
 
-fn tb_mouse_up(mut tb TextBox, e &MouseEvent, zzz voidptr) {
+fn tb_mouse_up(mut tb TextBox, e &MouseEvent, _ voidptr) {
 	if tb.hidden {
 		return
 	}

--- a/src/tool_calculate.v
+++ b/src/tool_calculate.v
@@ -25,7 +25,7 @@ pub fn mini_calc() MiniCalc {
 	return mc
 }
 
-fn compute_repl(re regex.RE, in_txt string, start int, end int) string {
+fn compute_repl(re regex.RE, in_txt string, _ int, _ int) string {
 	left := re.get_group_by_id(in_txt, 0)
 	op := re.get_group_by_id(in_txt, 1)
 	right := re.get_group_by_id(in_txt, 2)

--- a/src/transition.v
+++ b/src/transition.v
@@ -86,10 +86,10 @@ pub fn (mut t Transition) set_value(animated_value &int) {
 	t.last_draw_target = *animated_value
 }
 
-fn (t &Transition) set_pos(x int, y int) {
+fn (t &Transition) set_pos(_ int, _ int) {
 }
 
-fn (t &Transition) propose_size(w int, h int) (int, int) {
+fn (t &Transition) propose_size(_ int, _ int) (int, int) {
 	return 0, 0
 }
 
@@ -101,7 +101,7 @@ fn (mut t Transition) draw() {
 	t.draw_device(mut t.ui.dd)
 }
 
-fn (mut t Transition) draw_device(mut d DrawDevice) {
+fn (mut t Transition) draw_device(mut _ DrawDevice) {
 	if t.animated_value == 0 {
 		return
 	}
@@ -140,9 +140,9 @@ fn (mut t Transition) draw_device(mut d DrawDevice) {
 	}
 }
 
-fn (t &Transition) set_visible(state bool) {
+fn (t &Transition) set_visible(_ bool) {
 }
 
-fn (t &Transition) point_inside(x f64, y f64) bool {
+fn (t &Transition) point_inside(_ f64, _ f64) bool {
 	return false
 }

--- a/src/widget_checkbox.v
+++ b/src/widget_checkbox.v
@@ -131,7 +131,7 @@ pub fn (cb &CheckBox) free() {
 // 	dtw.update_text_size(cb.text_size)
 // }
 
-fn cb_key_down(mut cb CheckBox, e &KeyEvent, window &Window) {
+fn cb_key_down(mut cb CheckBox, e &KeyEvent, _ &Window) {
 	// println('key down $e <$e.key> <$e.codepoint> <$e.mods>')
 	// println('key down key=<$e.key> code=<$e.codepoint> mods=<$e.mods>')
 	$if cb_keydown ? {
@@ -156,7 +156,7 @@ fn cb_key_down(mut cb CheckBox, e &KeyEvent, window &Window) {
 	}
 }
 
-fn cb_click(mut cb CheckBox, e &MouseEvent, window &Window) {
+fn cb_click(mut cb CheckBox, e &MouseEvent, _ &Window) {
 	if cb.hidden {
 		return
 	}
@@ -259,7 +259,7 @@ fn (cb &CheckBox) point_inside(x f64, y f64) bool {
 	return point_inside(cb, x, y)
 }
 
-fn (mut cb CheckBox) mouse_move(e MouseEvent) {
+fn (mut cb CheckBox) mouse_move(_ MouseEvent) {
 }
 
 pub fn (mut cb CheckBox) set_visible(state bool) {

--- a/src/window.v
+++ b/src/window.v
@@ -754,7 +754,7 @@ fn on_event(e &gg.Event, mut window Window) {
 	*/
 }
 
-fn window_resize(event gg.Event, u &UI) {
+fn window_resize(_ gg.Event, u &UI) {
 	mut window := u.window
 	if !window.resizable {
 		return
@@ -1005,7 +1005,7 @@ fn window_scroll(event gg.Event, u &UI) {
 	window.eventbus.publish(events.on_scroll, window, e)
 }
 
-fn window_touch_down(event gg.Event, u &UI) {
+fn window_touch_down(_ gg.Event, u &UI) {
 	mut window := u.window
 	e := MouseEvent{
 		action: .down
@@ -1019,7 +1019,7 @@ fn window_touch_down(event gg.Event, u &UI) {
 	window.eventbus.publish(events.on_touch_down, window, e)
 }
 
-fn window_touch_move(event gg.Event, u &UI) {
+fn window_touch_move(_ gg.Event, u &UI) {
 	window := u.window
 	e := MouseMoveEvent{
 		x:            f64(window.touch.move.pos.x)
@@ -1032,7 +1032,7 @@ fn window_touch_move(event gg.Event, u &UI) {
 	window.eventbus.publish(events.on_touch_move, window, e)
 }
 
-fn window_touch_up(event gg.Event, u &UI) {
+fn window_touch_up(_ gg.Event, u &UI) {
 	window := u.window
 	e := MouseEvent{
 		action: .up
@@ -1071,7 +1071,7 @@ fn window_click_or_touch_tap(event gg.Event, u &UI) {
 	}
 }
 
-fn window_touch_scroll(event gg.Event, u &UI) {
+fn window_touch_scroll(_ gg.Event, u &UI) {
 	mut window := u.window
 	// println('title =$window.title')
 	s, m := window.touch.start, window.touch.move


### PR DESCRIPTION
## Summary

- Rename unused callback parameters to `_` to silence V's "declared but never used" errors (`accordion`, `alpha`, `colorbox`, `colorsliders`, `gg_app`, `grid`, `rasterview`, `splitpanel`, `tabs`)
- Fix `fontchooser_lb_change`: declare `fc` as `mut` so the `DrawTextWidget` cast on `fc.dtw` is valid
- Fix `hideable_add_shortcut`: use `unsafe{}` for `Shortcutable` cast from immutable `&ui.Window`
- Fix `src/chunkview.v`: wrap `DrawTextWidget(cv)` casts in `unsafe{}` where `cv` is `&ChunkView`
- Fix `src/layout_canvas.v`: same `unsafe{}` treatment for `DrawTextWidget(c)` from `&CanvasLayout`

## Context

These are all hard compile errors under the current V compiler (as of April 2026). The `unsafe{}` casts for `DrawTextWidget` are necessary because V's checker now rejects creating a mutable interface value from an immutable pointer (`&T`). The underlying data is heap-allocated and valid; `unsafe{}` tells the compiler to trust the programmer's intent here.

This PR is part of effort to restore the `v-apps-compile` CI job in vlang/v — tracked at vlang/v#26853.

## Test plan

- [ ] Compile `vlang/ui` with latest V: `v .`
- [ ] Verify no unused-variable or immutability errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)